### PR TITLE
chore: prepare 0.2.3 reliability release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: cargo test --manifest-path src-tauri/Cargo.toml
 
       - name: Run Clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 9.15.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm build
+
+  rust:
+    name: Rust checks
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Check Rust formatting
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
+
+      - name: Run Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+      - name: Run Clippy
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,20 +27,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 9
+          version: 9.15.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
 
       - name: Add macOS targets
         if: matrix.platform == 'macos-latest'
@@ -55,10 +56,10 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install frontend dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
   "name": "sklad",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
+  "description": "Local-only, tray-first snippet manager",
+  "author": "Pavel (Rench321)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Rench321/sklad.git"
+  },
+  "homepage": "https://rench321.github.io/sklad/",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/site/index.html
+++ b/site/index.html
@@ -54,7 +54,9 @@
           rel="noreferrer"
         >
           GitHub
-          <span aria-hidden="true">↗</span>
+          <svg aria-hidden="true" class="link-icon" viewBox="0 0 24 24">
+            <path d="M7 17 17 7M8 7h9v9" />
+          </svg>
         </a>
       </div>
     </header>
@@ -81,14 +83,18 @@
                 href="https://github.com/Rench321/sklad/releases/latest"
               >
                 Download latest release
-                <span aria-hidden="true">↓</span>
+                <svg aria-hidden="true" class="button-icon" viewBox="0 0 24 24">
+                  <path d="M12 3v12m0 0 5-5m-5 5-5-5M5 21h14" />
+                </svg>
               </a>
               <a
                 class="button button-secondary"
                 href="https://github.com/Rench321/sklad"
               >
                 View source
-                <span aria-hidden="true">↗</span>
+                <svg aria-hidden="true" class="button-icon" viewBox="0 0 24 24">
+                  <path d="M7 17 17 7M8 7h9v9" />
+                </svg>
               </a>
             </div>
 
@@ -114,14 +120,24 @@
               />
             </div>
             <div class="visual-note visual-note-lock">
-              <span aria-hidden="true">◆</span>
+              <span class="visual-note-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <rect x="5" y="10" width="14" height="10" rx="2" />
+                  <path d="M8 10V7a4 4 0 0 1 8 0v3M12 14v2" />
+                </svg>
+              </span>
               <div>
                 <strong>AES-256-GCM</strong>
                 <small>Encrypted on your device</small>
               </div>
             </div>
             <div class="visual-note visual-note-speed">
-              <strong>⌘ / Ctrl</strong>
+              <strong class="shortcut-keys">
+                <svg aria-hidden="true" viewBox="0 0 24 24">
+                  <path d="M9 6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6Z" />
+                </svg>
+                <span>/ Ctrl</span>
+              </strong>
               <small>Global access</small>
             </div>
           </div>
@@ -151,32 +167,57 @@
           <div class="feature-grid">
             <article class="feature-card feature-card-wide">
               <span class="feature-number">01</span>
-              <div class="feature-icon" aria-hidden="true">⌕</div>
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <circle cx="11" cy="11" r="6" />
+                  <path d="m16 16 4 4" />
+                </svg>
+              </div>
               <h3>Find anything instantly</h3>
               <p>
                 Open global search from any application, find a snippet, and copy it
                 without breaking your flow.
               </p>
-              <div class="shortcut"><kbd>Ctrl</kbd><span>+</span><kbd>Space</kbd></div>
+              <div class="shortcut">
+                <kbd>Ctrl</kbd>
+                <span class="shortcut-separator" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M12 6v12M6 12h12" /></svg>
+                </span>
+                <kbd>Space</kbd>
+              </div>
             </article>
 
             <article class="feature-card">
               <span class="feature-number">02</span>
-              <div class="feature-icon" aria-hidden="true">▣</div>
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <rect x="3" y="4" width="7" height="5" rx="1.5" />
+                  <rect x="14" y="15" width="7" height="5" rx="1.5" />
+                  <path d="M6.5 9v8.5H14M6.5 13h7.5" />
+                </svg>
+              </div>
               <h3>Nested organization</h3>
               <p>Keep growing collections readable with folders and drag-and-drop.</p>
             </article>
 
             <article class="feature-card">
               <span class="feature-number">03</span>
-              <div class="feature-icon" aria-hidden="true">✦</div>
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <path d="M6 3h8l4 4v14H6zM14 3v5h5M12 11v6M9 14h6" />
+                </svg>
+              </div>
               <h3>Instant creation</h3>
               <p>Capture a new snippet from anywhere with a configurable shortcut.</p>
             </article>
 
             <article class="feature-card">
               <span class="feature-number">04</span>
-              <div class="feature-icon" aria-hidden="true">↻</div>
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <path d="M20 11a8 8 0 1 0-2.35 5.65M20 5v6h-6" />
+                </svg>
+              </div>
               <h3>Autosave and backups</h3>
               <p>Work naturally while Sklad keeps local recovery points for you.</p>
             </article>
@@ -238,7 +279,10 @@
               class="text-link"
               href="https://github.com/Rench321/sklad"
             >
-              Inspect the source code <span aria-hidden="true">↗</span>
+              Inspect the source code
+              <svg aria-hidden="true" class="link-icon" viewBox="0 0 24 24">
+                <path d="M7 17 17 7M8 7h9v9" />
+              </svg>
             </a>
           </div>
 
@@ -289,25 +333,47 @@
                 class="button button-primary"
                 href="https://github.com/Rench321/sklad/releases/latest"
               >
-                Open latest release <span aria-hidden="true">↗</span>
+                Open latest release
+                <svg aria-hidden="true" class="button-icon" viewBox="0 0 24 24">
+                  <path d="M7 17 17 7M8 7h9v9" />
+                </svg>
               </a>
             </div>
 
             <div class="platform-cards">
               <a href="https://github.com/Rench321/sklad/releases/latest">
-                <span class="platform-icon" aria-hidden="true">⊞</span>
+                <span class="platform-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path class="fill-icon" d="M3 4.7 10.6 3.6v7.7H3zm8.6-1.2L21 2.2v9.1h-9.4zM3 12.7h7.6v7.7L3 19.3zm8.6 0H21v9.1l-9.4-1.3z" />
+                  </svg>
+                </span>
                 <span><strong>Windows</strong><small>.msi or .exe</small></span>
-                <b aria-hidden="true">→</b>
+                <span class="platform-arrow" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M5 12h14m-5-5 5 5-5 5" /></svg>
+                </span>
               </a>
               <a href="https://github.com/Rench321/sklad/releases/latest">
-                <span class="platform-icon" aria-hidden="true">●</span>
+                <span class="platform-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path class="fill-icon" d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.29-.05 2.2.71 2.96.77 1.13-.23 2.21-.89 3.42-.8 1.45.12 2.54.69 3.27 1.73-2.99 1.79-2.28 5.73.46 6.83-.55 1.45-1.27 2.89-2.11 4.44M12.03 7.25C11.88 5.1 13.63 3.33 15.64 3.16c.28 2.49-2.26 4.35-3.61 4.09" />
+                  </svg>
+                </span>
                 <span><strong>macOS</strong><small>Apple Silicon &amp; Intel</small></span>
-                <b aria-hidden="true">→</b>
+                <span class="platform-arrow" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M5 12h14m-5-5 5 5-5 5" /></svg>
+                </span>
               </a>
               <a href="https://github.com/Rench321/sklad/releases/latest">
-                <span class="platform-icon" aria-hidden="true">◇</span>
+                <span class="platform-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <rect x="3" y="4" width="18" height="16" rx="3" />
+                    <path d="m7 9 3 3-3 3M13 15h4" />
+                  </svg>
+                </span>
                 <span><strong>Linux</strong><small>.deb, .rpm or AppImage</small></span>
-                <b aria-hidden="true">→</b>
+                <span class="platform-arrow" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M5 12h14m-5-5 5 5-5 5" /></svg>
+                </span>
               </a>
             </div>
           </div>
@@ -327,28 +393,48 @@
           </div>
           <div class="faq-list">
             <details>
-              <summary>Does Sklad connect to the internet?<span>+</span></summary>
+              <summary>
+                Does Sklad connect to the internet?
+                <svg aria-hidden="true" class="faq-icon" viewBox="0 0 24 24">
+                  <path d="M12 5v14M5 12h14" />
+                </svg>
+              </summary>
               <p>
                 No. The application is designed to work fully offline and does not
                 perform telemetry or update checks.
               </p>
             </details>
             <details>
-              <summary>Where is my data stored?<span>+</span></summary>
+              <summary>
+                Where is my data stored?
+                <svg aria-hidden="true" class="faq-icon" viewBox="0 0 24 24">
+                  <path d="M12 5v14M5 12h14" />
+                </svg>
+              </summary>
               <p>
                 In your operating system's local application-data directory. Sklad can
                 open that location for you from Settings.
               </p>
             </details>
             <details>
-              <summary>Why does my OS show a warning?<span>+</span></summary>
+              <summary>
+                Why does my OS show a warning?
+                <svg aria-hidden="true" class="faq-icon" viewBox="0 0 24 24">
+                  <path d="M12 5v14M5 12h14" />
+                </svg>
+              </summary>
               <p>
                 Current builds are not code-signed or notarized. The release notes
                 include platform-specific installation guidance.
               </p>
             </details>
             <details>
-              <summary>How do I know when an update is available?<span>+</span></summary>
+              <summary>
+                How do I know when an update is available?
+                <svg aria-hidden="true" class="faq-icon" viewBox="0 0 24 24">
+                  <path d="M12 5v14M5 12h14" />
+                </svg>
+              </summary>
               <p>
                 Visit GitHub Releases or update through your package manager. Sklad
                 intentionally does not make network requests to check for updates.

--- a/site/index.html
+++ b/site/index.html
@@ -169,8 +169,8 @@
               <span class="feature-number">01</span>
               <div class="feature-icon" aria-hidden="true">
                 <svg viewBox="0 0 24 24">
-                  <circle cx="11" cy="11" r="6" />
-                  <path d="m16 16 4 4" />
+                  <path d="m21 21-4.34-4.34" />
+                  <circle cx="11" cy="11" r="8" />
                 </svg>
               </div>
               <h3>Find anything instantly</h3>
@@ -191,9 +191,10 @@
               <span class="feature-number">02</span>
               <div class="feature-icon" aria-hidden="true">
                 <svg viewBox="0 0 24 24">
-                  <rect x="3" y="4" width="7" height="5" rx="1.5" />
-                  <rect x="14" y="15" width="7" height="5" rx="1.5" />
-                  <path d="M6.5 9v8.5H14M6.5 13h7.5" />
+                  <path d="M20 10a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2.5a1 1 0 0 1-.8-.4l-.9-1.2A1 1 0 0 0 15 3h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z" />
+                  <path d="M20 21a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-2.9a1 1 0 0 1-.88-.55l-.42-.85a1 1 0 0 0-.92-.6H13a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z" />
+                  <path d="M3 5a2 2 0 0 0 2 2h3" />
+                  <path d="M3 3v13a2 2 0 0 0 2 2h3" />
                 </svg>
               </div>
               <h3>Nested organization</h3>
@@ -204,7 +205,10 @@
               <span class="feature-number">03</span>
               <div class="feature-icon" aria-hidden="true">
                 <svg viewBox="0 0 24 24">
-                  <path d="M6 3h8l4 4v14H6zM14 3v5h5M12 11v6M9 14h6" />
+                  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2Z" />
+                  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+                  <path d="M9 15h6" />
+                  <path d="M12 18v-6" />
                 </svg>
               </div>
               <h3>Instant creation</h3>
@@ -215,7 +219,9 @@
               <span class="feature-number">04</span>
               <div class="feature-icon" aria-hidden="true">
                 <svg viewBox="0 0 24 24">
-                  <path d="M20 11a8 8 0 1 0-2.35 5.65M20 5v6h-6" />
+                  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                  <path d="M3 3v5h5" />
+                  <path d="M12 7v5l4 2" />
                 </svg>
               </div>
               <h3>Autosave and backups</h3>
@@ -225,8 +231,16 @@
             <article class="feature-card feature-card-dark">
               <span class="feature-number">05</span>
               <div class="feature-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" focusable="false">
-                  <path d="M4 6h5m4 0h7M9 3v6M4 12h9m4 0h3M13 9v6M4 18h3m4 0h9M7 15v6" />
+                <svg viewBox="0 0 24 24">
+                  <path d="M10 5H3" />
+                  <path d="M12 19H3" />
+                  <path d="M14 3v4" />
+                  <path d="M16 17v4" />
+                  <path d="M21 12h-9" />
+                  <path d="M21 19h-5" />
+                  <path d="M21 5h-7" />
+                  <path d="M8 10v4" />
+                  <path d="M8 12H3" />
                 </svg>
               </div>
               <h3>Your desktop, your way</h3>

--- a/site/styles.css
+++ b/site/styles.css
@@ -159,14 +159,28 @@ summary {
 }
 
 .header-link {
+  display: inline-flex;
+  align-items: center;
   justify-self: end;
+  gap: 6px;
   color: var(--muted);
   font-size: 0.84rem;
   font-weight: 700;
 }
 
-.header-link span {
-  margin-left: 5px;
+.link-icon,
+.button-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.header-link .link-icon {
   color: var(--amber);
 }
 
@@ -261,7 +275,7 @@ h1 em {
   align-items: center;
   justify-content: center;
   min-height: 50px;
-  padding: 0 19px;
+  padding: 0 17px 0 19px;
   gap: 18px;
   border: 1px solid transparent;
   border-radius: 9px;
@@ -316,9 +330,14 @@ h1 em {
 }
 
 .platform-list li::before {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
   margin-right: 8px;
-  color: var(--amber);
-  content: "·";
+  border-radius: 50%;
+  background: var(--amber);
+  content: "";
+  vertical-align: 0.15em;
 }
 
 .hero-visual {
@@ -430,12 +449,38 @@ h1 em {
   color: var(--amber);
 }
 
+.visual-note-icon svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
 .visual-note-speed {
   right: -18px;
   bottom: 74px;
   flex-direction: column;
   align-items: flex-start;
   gap: 1px;
+}
+
+.shortcut-keys {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 4px;
+}
+
+.shortcut-keys svg {
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
 }
 
 .trust-row {
@@ -614,6 +659,22 @@ h1 em {
   font-size: 0.75rem;
 }
 
+.shortcut-separator {
+  display: grid;
+  width: 12px;
+  height: 12px;
+  place-items: center;
+}
+
+.shortcut-separator svg {
+  width: 10px;
+  height: 10px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 2;
+}
+
 kbd {
   padding: 5px 8px;
   border: 1px solid var(--line-dark);
@@ -727,6 +788,7 @@ kbd {
 
 .text-link {
   display: inline-flex;
+  align-items: center;
   gap: 10px;
   color: var(--amber);
   font-size: 0.85rem;
@@ -844,6 +906,22 @@ kbd {
   place-items: center;
 }
 
+.platform-icon svg,
+.platform-arrow svg {
+  width: 19px;
+  height: 19px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.platform-icon .fill-icon {
+  fill: currentColor;
+  stroke: none;
+}
+
 .platform-cards strong,
 .platform-cards small {
   display: block;
@@ -859,14 +937,18 @@ kbd {
   font-size: 0.68rem;
 }
 
-.platform-cards b {
+.platform-arrow {
   display: grid;
   width: 24px;
   height: 24px;
   transform: translateY(-1px);
   color: #9d9d94;
-  font-size: 0.82rem;
   place-items: center;
+}
+
+.platform-arrow svg {
+  width: 15px;
+  height: 15px;
 }
 
 .install-note {
@@ -922,14 +1004,19 @@ kbd {
   display: none;
 }
 
-.faq-list summary span {
+.faq-icon {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
   color: #a1680d;
-  font-size: 1.3rem;
-  font-weight: 400;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.6;
   transition: transform 160ms ease;
 }
 
-.faq-list details[open] summary span {
+.faq-list details[open] summary .faq-icon {
   transform: rotate(45deg);
 }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -545,6 +545,10 @@ h1 em {
   line-height: 0.98;
 }
 
+.download-copy h2 {
+  line-height: 1.08;
+}
+
 .section-heading > p,
 .demo-copy > p,
 .download-copy > p {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3920,7 +3920,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sklad"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "sklad"
-version = "0.2.2"
-description = "Tray Snippet Manager"
-authors = ["you"]
+version = "0.2.3"
+description = "Local-only, tray-first snippet manager"
+authors = ["Pavel (Rench321)"]
+homepage = "https://rench321.github.io/sklad/"
+repository = "https://github.com/Rench321/sklad"
+license = "MIT"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -132,7 +132,7 @@ fn has_plain_secrets(nodes: &[Node]) -> bool {
         let is_plain_secret = matches!(n.node_type, NodeType::Snippet)
             && n.is_secret.unwrap_or(false)
             && n.value.is_some();
-        is_plain_secret || n.children.as_ref().map_or(false, |c| has_plain_secrets(c))
+        is_plain_secret || n.children.as_deref().is_some_and(has_plain_secrets)
     })
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,15 +10,20 @@ const SALT_SIZE: usize = 16;
 const ENCRYPTED_VALUE_SEPARATOR: char = ':';
 
 #[tauri::command]
-pub fn get_data(app: AppHandle, vault_manager: State<'_, VaultManager>) -> Vec<Node> {
+pub fn get_data(
+    app: AppHandle,
+    vault_manager: State<'_, VaultManager>,
+) -> Result<Vec<Node>, String> {
     let data_manager = DataManager::new(&app);
-    let mut nodes = data_manager.load_data();
+    let mut nodes = data_manager
+        .load_data()
+        .map_err(|error| error.to_string())?;
 
     if let VaultState::Unlocked(key) = &*vault_manager.state.lock().unwrap() {
         decrypt_nodes_recursive(&mut nodes, key);
     }
 
-    nodes
+    Ok(nodes)
 }
 
 #[tauri::command]
@@ -35,17 +40,20 @@ pub fn init_vault(
 
     let key = security::derive_key_from_password(&password, &salt);
 
-    *vault_manager.state.lock().unwrap() = VaultState::Unlocked(key);
-
     let data_manager = DataManager::new(&app);
-    let mut settings = data_manager.load_settings();
+    let mut settings = data_manager
+        .load_settings()
+        .map_err(|error| error.to_string())?;
     settings.security.master_password_enabled = true;
     settings.security.password_hash = Some(hash);
     settings.security.derivation_salt = Some(salt);
 
     data_manager
         .save_settings(&settings)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    *vault_manager.state.lock().unwrap() = VaultState::Unlocked(key);
+    Ok(())
 }
 
 #[tauri::command]
@@ -55,7 +63,9 @@ pub fn unlock_vault(
     password: String,
 ) -> Result<bool, String> {
     let data_manager = DataManager::new(&app);
-    let settings = data_manager.load_settings();
+    let settings = data_manager
+        .load_settings()
+        .map_err(|error| error.to_string())?;
 
     if let Some(hash) = &settings.security.password_hash {
         if !security::verify_password(&password, hash) {
@@ -142,6 +152,14 @@ pub fn save_data(
     vault_manager: State<'_, VaultManager>,
     mut nodes: Vec<Node>,
 ) -> Result<(), String> {
+    let data_manager = DataManager::new(&app);
+    data_manager
+        .load_data()
+        .map_err(|error| error.to_string())?;
+    let settings = data_manager
+        .load_settings()
+        .map_err(|error| error.to_string())?;
+
     if has_plain_secrets(&nodes) {
         let state = vault_manager.state.lock().unwrap();
         match &*state {
@@ -150,10 +168,8 @@ pub fn save_data(
         }
     }
 
-    let data_manager = DataManager::new(&app);
     data_manager.save_data(&nodes).map_err(|e| e.to_string())?;
 
-    let settings = data_manager.load_settings();
     if settings.auto_backup_enabled {
         if let Err(e) = data_manager.create_backup() {
             log::error!("Failed to create backup after save: {}", e);
@@ -162,7 +178,7 @@ pub fn save_data(
         }
     }
 
-    let menu = crate::tray_generator::TrayGenerator::generate_menu(&app, &nodes)
+    let menu = crate::tray_generator::TrayGenerator::generate_menu(&app, &nodes, &settings)
         .map_err(|e| e.to_string())?;
     if let Some(tray) = app.tray_by_id("main") {
         let _ = tray.set_menu(Some(menu));
@@ -178,7 +194,12 @@ pub fn copy_snippet<R: Runtime>(
     id: String,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
-    let nodes = data_manager.load_data();
+    let nodes = data_manager
+        .load_data()
+        .map_err(|error| error.to_string())?;
+    let settings = data_manager
+        .load_settings()
+        .map_err(|error| error.to_string())?;
 
     let node = DataManager::find_node_by_id(&nodes, &id).ok_or("Snippet not found")?;
 
@@ -205,7 +226,6 @@ pub fn copy_snippet<R: Runtime>(
 
     *vault_manager.last_used_id.lock().unwrap() = Some(id);
 
-    let settings = data_manager.load_settings();
     if settings.notifications_enabled {
         let _ = app
             .notification()
@@ -219,8 +239,10 @@ pub fn copy_snippet<R: Runtime>(
 }
 
 #[tauri::command]
-pub fn get_settings(app: AppHandle) -> crate::models::AppSettings {
-    DataManager::new(&app).load_settings()
+pub fn get_settings(app: AppHandle) -> Result<crate::models::AppSettings, String> {
+    DataManager::new(&app)
+        .load_settings()
+        .map_err(|error| error.to_string())
 }
 
 #[tauri::command]
@@ -229,6 +251,17 @@ pub fn save_settings(
     vault_manager: State<'_, VaultManager>,
     settings: crate::models::AppSettings,
 ) -> Result<(), String> {
+    let data_manager = DataManager::new(&app);
+    data_manager
+        .load_settings()
+        .map_err(|error| error.to_string())?;
+    let nodes = data_manager
+        .load_data()
+        .map_err(|error| error.to_string())?;
+    data_manager
+        .save_settings(&settings)
+        .map_err(|e| format!("Failed to save settings: {}", e))?;
+
     if !settings.security.master_password_enabled {
         *vault_manager.state.lock().unwrap() = VaultState::Locked;
     }
@@ -283,13 +316,7 @@ pub fn save_settings(
         }
     }
 
-    let data_manager = DataManager::new(&app);
-    data_manager
-        .save_settings(&settings)
-        .map_err(|e| format!("Failed to save settings: {}", e))?;
-
-    let nodes = data_manager.load_data();
-    if let Ok(menu) = crate::tray_generator::TrayGenerator::generate_menu(&app, &nodes) {
+    if let Ok(menu) = crate::tray_generator::TrayGenerator::generate_menu(&app, &nodes, &settings) {
         if let Some(tray) = app.tray_by_id("main") {
             let _ = tray.set_menu(Some(menu));
         }
@@ -324,6 +351,20 @@ pub fn open_snippets_path(app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub fn open_data_directory(app: AppHandle) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    let data_manager = DataManager::new(&app);
+    let directory = data_manager
+        .file_path
+        .parent()
+        .ok_or_else(|| "Failed to resolve application data directory".to_string())?;
+    app.opener()
+        .open_path(directory.to_string_lossy(), None::<String>)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
 pub fn open_app_logs_dir(app: AppHandle) -> Result<(), String> {
     use tauri::Manager;
     use tauri_plugin_opener::OpenerExt;
@@ -348,8 +389,12 @@ pub fn reset_vault(
     vault_manager: State<'_, VaultManager>,
 ) -> Result<(Vec<Node>, crate::models::AppSettings), String> {
     let data_manager = DataManager::new(&app);
-    let mut nodes = data_manager.load_data();
-    let mut settings = data_manager.load_settings();
+    let mut nodes = data_manager
+        .load_data()
+        .map_err(|error| error.to_string())?;
+    let mut settings = data_manager
+        .load_settings()
+        .map_err(|error| error.to_string())?;
 
     remove_secrets_recursive(&mut nodes);
     settings.security.master_password_enabled = false;
@@ -376,7 +421,9 @@ fn remove_secrets_recursive(nodes: &mut Vec<Node>) {
 #[tauri::command]
 pub fn create_backup(app: AppHandle) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
-    let settings = data_manager.load_settings();
+    let settings = data_manager
+        .load_settings()
+        .map_err(|error| error.to_string())?;
 
     data_manager.create_backup().map_err(|e| e.to_string())?;
     data_manager
@@ -395,15 +442,64 @@ pub fn get_backups(app: AppHandle) -> Vec<crate::models::BackupInfo> {
 pub fn restore_backup(app: AppHandle, filename: String) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
     data_manager.restore_backup(&filename)?;
-
-    let nodes = data_manager.load_data();
-    let menu = crate::tray_generator::TrayGenerator::generate_menu(&app, &nodes)
-        .map_err(|e| e.to_string())?;
-    if let Some(tray) = app.tray_by_id("main") {
-        tray.set_menu(Some(menu)).map_err(|e| e.to_string())?;
-    }
+    refresh_tray_from_storage(&app, &data_manager)?;
 
     app.emit("data-updated", ()).map_err(|e| e.to_string())?;
 
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_storage_status(app: AppHandle) -> crate::data_manager::StorageStatus {
+    DataManager::new(&app).storage_status()
+}
+
+#[tauri::command]
+pub fn reset_corrupt_data(app: AppHandle) -> Result<String, String> {
+    let data_manager = DataManager::new(&app);
+    let quarantined = data_manager.reset_invalid_data()?;
+    refresh_tray_from_storage(&app, &data_manager)?;
+
+    app.emit("data-updated", ())
+        .map_err(|error| error.to_string())?;
+    Ok(quarantined)
+}
+
+#[tauri::command]
+pub fn reset_corrupt_settings(
+    app: AppHandle,
+    vault_manager: State<'_, VaultManager>,
+) -> Result<String, String> {
+    let data_manager = DataManager::new(&app);
+    let quarantined = data_manager.reset_invalid_settings()?;
+    *vault_manager.state.lock().unwrap() = VaultState::Locked;
+    crate::LOGGING_ENABLED.store(false, std::sync::atomic::Ordering::Relaxed);
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+    let _ = app.global_shortcut().unregister_all();
+    refresh_tray_from_storage(&app, &data_manager)?;
+    Ok(quarantined)
+}
+
+fn refresh_tray_from_storage(app: &AppHandle, data_manager: &DataManager) -> Result<(), String> {
+    let settings_result = data_manager.load_settings();
+    let nodes_result = data_manager.load_data();
+    let storage_is_healthy = settings_result.is_ok() && nodes_result.is_ok();
+
+    let mut settings = settings_result.unwrap_or_default();
+    if !storage_is_healthy {
+        settings.auto_backup_enabled = false;
+    }
+    let nodes = nodes_result.unwrap_or_default();
+    let menu_nodes = if storage_is_healthy {
+        nodes.as_slice()
+    } else {
+        &[]
+    };
+    let menu = crate::tray_generator::TrayGenerator::generate_menu(app, menu_nodes, &settings)
+        .map_err(|error| error.to_string())?;
+    if let Some(tray) = app.tray_by_id("main") {
+        tray.set_menu(Some(menu))
+            .map_err(|error| error.to_string())?;
+    }
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,13 +9,52 @@ use tauri_plugin_notification::NotificationExt;
 const SALT_SIZE: usize = 16;
 const ENCRYPTED_VALUE_SEPARATOR: char = ':';
 
+fn ensure_storage_healthy<R: Runtime>(
+    app: &AppHandle<R>,
+    data_manager: &DataManager,
+) -> Result<(), String> {
+    data_manager.ensure_storage_healthy().inspect_err(|_| {
+        let _ = app.emit("storage-recovery-required", ());
+    })
+}
+
+fn sync_global_shortcuts<R: Runtime>(app: &AppHandle<R>, settings: &crate::models::AppSettings) {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+    let _ = app.global_shortcut().unregister_all();
+    for (name, configured) in [
+        ("search", settings.global_search_shortcut.as_str()),
+        ("create", settings.global_create_shortcut.as_str()),
+    ] {
+        if configured.is_empty() {
+            continue;
+        }
+
+        match configured.parse::<tauri_plugin_global_shortcut::Shortcut>() {
+            Ok(shortcut) => {
+                if let Err(error) = app.global_shortcut().register(shortcut) {
+                    log::error!("Failed to register {} shortcut: {}", name, error);
+                }
+            }
+            Err(error) => {
+                log::error!(
+                    "Failed to parse {} shortcut string '{}': {}",
+                    name,
+                    configured,
+                    error
+                );
+            }
+        }
+    }
+}
+
 #[tauri::command]
 pub fn get_data(
     app: AppHandle,
     vault_manager: State<'_, VaultManager>,
 ) -> Result<Vec<Node>, String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     let mut nodes = data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
@@ -34,7 +73,7 @@ pub fn init_vault(
     password: String,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     let hash = security::hash_password(&password);
 
     let mut salt_bytes = [0u8; SALT_SIZE];
@@ -65,7 +104,7 @@ pub fn unlock_vault(
     password: String,
 ) -> Result<bool, String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     let settings = data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
@@ -160,7 +199,7 @@ pub fn save_data(
     mut nodes: Vec<Node>,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
@@ -206,7 +245,7 @@ pub fn copy_snippet<R: Runtime>(
     id: String,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     let nodes = data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
@@ -254,7 +293,7 @@ pub fn copy_snippet<R: Runtime>(
 #[tauri::command]
 pub fn get_settings(app: AppHandle) -> Result<crate::models::AppSettings, String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     data_manager
         .load_settings()
         .map_err(|error| error.to_string())
@@ -267,7 +306,7 @@ pub fn save_settings(
     settings: crate::models::AppSettings,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
@@ -301,50 +340,7 @@ pub fn save_settings(
         std::sync::atomic::Ordering::Relaxed,
     );
 
-    use tauri_plugin_global_shortcut::GlobalShortcutExt;
-    let _ = app.global_shortcut().unregister_all();
-
-    // Register Search Shortcut
-    if !settings.global_search_shortcut.is_empty() {
-        match settings
-            .global_search_shortcut
-            .parse::<tauri_plugin_global_shortcut::Shortcut>()
-        {
-            Ok(shortcut) => {
-                if let Err(e) = app.global_shortcut().register(shortcut) {
-                    log::error!("Failed to register search shortcut: {}", e);
-                }
-            }
-            Err(e) => {
-                log::error!(
-                    "Failed to parse search shortcut string '{}': {}",
-                    settings.global_search_shortcut,
-                    e
-                );
-            }
-        }
-    }
-
-    // Register Create Shortcut
-    if !settings.global_create_shortcut.is_empty() {
-        match settings
-            .global_create_shortcut
-            .parse::<tauri_plugin_global_shortcut::Shortcut>()
-        {
-            Ok(shortcut) => {
-                if let Err(e) = app.global_shortcut().register(shortcut) {
-                    log::error!("Failed to register create shortcut: {}", e);
-                }
-            }
-            Err(e) => {
-                log::error!(
-                    "Failed to parse create shortcut string '{}': {}",
-                    settings.global_create_shortcut,
-                    e
-                );
-            }
-        }
-    }
+    sync_global_shortcuts(&app, &settings);
 
     if let Ok(menu) = crate::tray_generator::TrayGenerator::generate_menu(&app, &nodes, &settings) {
         if let Some(tray) = app.tray_by_id("main") {
@@ -419,7 +415,7 @@ pub fn reset_vault(
     vault_manager: State<'_, VaultManager>,
 ) -> Result<(Vec<Node>, crate::models::AppSettings), String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     let mut nodes = data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
@@ -460,7 +456,7 @@ fn has_encrypted_values(nodes: &[Node]) -> bool {
 #[tauri::command]
 pub fn create_backup(app: AppHandle) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
-    data_manager.ensure_storage_healthy()?;
+    ensure_storage_healthy(&app, &data_manager)?;
     let settings = data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
@@ -479,12 +475,26 @@ pub fn get_backups(app: AppHandle) -> Vec<crate::models::BackupInfo> {
 }
 
 #[tauri::command]
-pub fn restore_backup(app: AppHandle, filename: String) -> Result<(), String> {
+pub fn restore_backup(
+    app: AppHandle,
+    vault_manager: State<'_, VaultManager>,
+    filename: String,
+) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
     data_manager.restore_backup(&filename)?;
+    *vault_manager.state.lock().unwrap() = VaultState::Locked;
+    let settings = data_manager
+        .load_settings()
+        .map_err(|issue| issue.to_string())?;
+    crate::LOGGING_ENABLED.store(
+        settings.logging_enabled,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    sync_global_shortcuts(&app, &settings);
     refresh_tray_from_storage(&app, &data_manager)?;
 
-    app.emit("data-updated", ()).map_err(|e| e.to_string())?;
+    app.emit("storage-restored", ())
+        .map_err(|error| error.to_string())?;
 
     Ok(())
 }
@@ -518,6 +528,28 @@ pub fn reset_corrupt_settings(
     let _ = app.global_shortcut().unregister_all();
     refresh_tray_from_storage(&app, &data_manager)?;
     Ok(quarantined)
+}
+
+#[tauri::command]
+pub fn recover_vault_metadata(
+    app: AppHandle,
+    vault_manager: State<'_, VaultManager>,
+) -> Result<Option<String>, String> {
+    let data_manager = DataManager::new(&app);
+    let recovery_copy = data_manager.recover_vault_metadata()?;
+    *vault_manager.state.lock().unwrap() = VaultState::Locked;
+    let settings = data_manager
+        .load_settings()
+        .map_err(|issue| issue.to_string())?;
+    crate::LOGGING_ENABLED.store(
+        settings.logging_enabled,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    sync_global_shortcuts(&app, &settings);
+    refresh_tray_from_storage(&app, &data_manager)?;
+    app.emit("data-updated", ())
+        .map_err(|error| error.to_string())?;
+    Ok(recovery_copy)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,6 +15,7 @@ pub fn get_data(
     vault_manager: State<'_, VaultManager>,
 ) -> Result<Vec<Node>, String> {
     let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     let mut nodes = data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
@@ -32,6 +33,8 @@ pub fn init_vault(
     vault_manager: State<'_, VaultManager>,
     password: String,
 ) -> Result<(), String> {
+    let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     let hash = security::hash_password(&password);
 
     let mut salt_bytes = [0u8; SALT_SIZE];
@@ -40,7 +43,6 @@ pub fn init_vault(
 
     let key = security::derive_key_from_password(&password, &salt);
 
-    let data_manager = DataManager::new(&app);
     let mut settings = data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
@@ -63,23 +65,28 @@ pub fn unlock_vault(
     password: String,
 ) -> Result<bool, String> {
     let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     let settings = data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
 
-    if let Some(hash) = &settings.security.password_hash {
-        if !security::verify_password(&password, hash) {
-            return Ok(false);
-        }
-    } else if settings.security.master_password_enabled {
-        return Err("Security enabled but no password hash found. Please reset vault.".into());
+    if !settings.security.master_password_enabled {
+        return Err("Vault is not enabled".to_string());
     }
 
+    let hash = settings
+        .security
+        .password_hash
+        .as_deref()
+        .ok_or_else(|| "Vault password verifier is missing; open recovery mode".to_string())?;
+    if !security::verify_password(&password, hash) {
+        return Ok(false);
+    }
     let salt = settings
         .security
         .derivation_salt
         .as_deref()
-        .unwrap_or("default-salt");
+        .ok_or_else(|| "Vault derivation salt is missing; open recovery mode".to_string())?;
     let key = security::derive_key_from_password(&password, salt);
 
     *vault_manager.state.lock().unwrap() = VaultState::Unlocked(key);
@@ -153,12 +160,17 @@ pub fn save_data(
     mut nodes: Vec<Node>,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
     let settings = data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
+
+    if !settings.security.master_password_enabled && has_encrypted_values(&nodes) {
+        return Err("Encrypted snippets require an enabled vault".to_string());
+    }
 
     if has_plain_secrets(&nodes) {
         let state = vault_manager.state.lock().unwrap();
@@ -194,6 +206,7 @@ pub fn copy_snippet<R: Runtime>(
     id: String,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     let nodes = data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
@@ -240,7 +253,9 @@ pub fn copy_snippet<R: Runtime>(
 
 #[tauri::command]
 pub fn get_settings(app: AppHandle) -> Result<crate::models::AppSettings, String> {
-    DataManager::new(&app)
+    let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
+    data_manager
         .load_settings()
         .map_err(|error| error.to_string())
 }
@@ -252,12 +267,27 @@ pub fn save_settings(
     settings: crate::models::AppSettings,
 ) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
     let nodes = data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
+    if settings.security.master_password_enabled
+        && (settings.security.password_hash.is_none()
+            || settings.security.derivation_salt.is_none())
+    {
+        return Err(
+            "Enabled vault settings require a password verifier and derivation salt".to_string(),
+        );
+    }
+    if !settings.security.master_password_enabled && has_encrypted_values(&nodes) {
+        return Err(
+            "Disable the vault through Reset Vault so encrypted snippets are handled safely"
+                .to_string(),
+        );
+    }
     data_manager
         .save_settings(&settings)
         .map_err(|e| format!("Failed to save settings: {}", e))?;
@@ -389,6 +419,7 @@ pub fn reset_vault(
     vault_manager: State<'_, VaultManager>,
 ) -> Result<(Vec<Node>, crate::models::AppSettings), String> {
     let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     let mut nodes = data_manager
         .load_data()
         .map_err(|error| error.to_string())?;
@@ -398,6 +429,8 @@ pub fn reset_vault(
 
     remove_secrets_recursive(&mut nodes);
     settings.security.master_password_enabled = false;
+    settings.security.password_hash = None;
+    settings.security.derivation_salt = None;
 
     data_manager.save_data(&nodes).map_err(|e| e.to_string())?;
     data_manager
@@ -410,7 +443,7 @@ pub fn reset_vault(
 }
 
 fn remove_secrets_recursive(nodes: &mut Vec<Node>) {
-    nodes.retain(|node| !node.is_secret.unwrap_or(false));
+    nodes.retain(|node| !node.is_secret.unwrap_or(false) && node.encrypted_value.is_none());
     for node in nodes.iter_mut() {
         if let Some(children) = &mut node.children {
             remove_secrets_recursive(children);
@@ -418,9 +451,16 @@ fn remove_secrets_recursive(nodes: &mut Vec<Node>) {
     }
 }
 
+fn has_encrypted_values(nodes: &[Node]) -> bool {
+    nodes.iter().any(|node| {
+        node.encrypted_value.is_some() || node.children.as_deref().is_some_and(has_encrypted_values)
+    })
+}
+
 #[tauri::command]
 pub fn create_backup(app: AppHandle) -> Result<(), String> {
     let data_manager = DataManager::new(&app);
+    data_manager.ensure_storage_healthy()?;
     let settings = data_manager
         .load_settings()
         .map_err(|error| error.to_string())?;
@@ -480,16 +520,40 @@ pub fn reset_corrupt_settings(
     Ok(quarantined)
 }
 
-fn refresh_tray_from_storage(app: &AppHandle, data_manager: &DataManager) -> Result<(), String> {
-    let settings_result = data_manager.load_settings();
-    let nodes_result = data_manager.load_data();
-    let storage_is_healthy = settings_result.is_ok() && nodes_result.is_ok();
+#[tauri::command]
+pub fn discard_unrecoverable_vault_data(
+    app: AppHandle,
+    vault_manager: State<'_, VaultManager>,
+) -> Result<crate::data_manager::VaultRecoveryResult, String> {
+    let data_manager = DataManager::new(&app);
+    let result = data_manager.discard_unrecoverable_vault_data()?;
+    *vault_manager.state.lock().unwrap() = VaultState::Locked;
+    crate::LOGGING_ENABLED.store(false, std::sync::atomic::Ordering::Relaxed);
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+    let _ = app.global_shortcut().unregister_all();
+    refresh_tray_from_storage(&app, &data_manager)?;
+    app.emit("data-updated", ())
+        .map_err(|error| error.to_string())?;
+    Ok(result)
+}
 
-    let mut settings = settings_result.unwrap_or_default();
+fn refresh_tray_from_storage(app: &AppHandle, data_manager: &DataManager) -> Result<(), String> {
+    let storage_is_healthy = !data_manager.has_storage_issues();
+    let (mut settings, nodes) = if storage_is_healthy {
+        (
+            data_manager
+                .load_settings()
+                .map_err(|error| error.to_string())?,
+            data_manager
+                .load_data()
+                .map_err(|error| error.to_string())?,
+        )
+    } else {
+        (crate::models::AppSettings::default(), Vec::new())
+    };
     if !storage_is_healthy {
         settings.auto_backup_enabled = false;
     }
-    let nodes = nodes_result.unwrap_or_default();
     let menu_nodes = if storage_is_healthy {
         nodes.as_slice()
     } else {

--- a/src-tauri/src/data_manager.rs
+++ b/src-tauri/src/data_manager.rs
@@ -909,6 +909,36 @@ mod tests {
         assert_eq!(settings.theme, "dark");
         assert!(!settings.security.master_password_enabled);
         assert_eq!(settings.auto_backup_count, 5);
+
+        manager.save_settings(&settings).unwrap();
+        let rewritten = std::fs::read_to_string(manager.settings_path()).unwrap();
+        assert!(!rewritten.contains("clearClipboard"));
+    }
+
+    #[test]
+    fn older_nodes_without_optional_secret_fields_remain_compatible() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        std::fs::write(
+            &manager.file_path,
+            br#"[{
+                "id":"legacy-id",
+                "type":"snippet",
+                "label":"Legacy snippet",
+                "parentId":null,
+                "createdAt":123,
+                "value":"legacy value"
+            }]"#,
+        )
+        .unwrap();
+
+        let nodes = manager.load_data().unwrap();
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].label, "Legacy snippet");
+        assert_eq!(nodes[0].value.as_deref(), Some("legacy value"));
+        assert!(nodes[0].encrypted_value.is_none());
+        assert!(nodes[0].is_secret.is_none());
     }
 
     #[test]

--- a/src-tauri/src/data_manager.rs
+++ b/src-tauri/src/data_manager.rs
@@ -1,9 +1,98 @@
 use crate::models::{BackupInfo, Node};
+use serde::{de::DeserializeOwned, Serialize};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager, Runtime};
 use tempfile::NamedTempFile;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageFile {
+    Data,
+    Settings,
+}
+
+impl StorageFile {
+    fn file_name(self) -> &'static str {
+        match self {
+            Self::Data => "sklad.json",
+            Self::Settings => "settings.json",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageIssueKind {
+    InvalidFormat,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageIssue {
+    pub file: StorageFile,
+    pub kind: StorageIssueKind,
+    pub file_name: String,
+    pub reason: String,
+}
+
+impl StorageIssue {
+    fn invalid(file: StorageFile, error: serde_json::Error) -> Self {
+        Self {
+            file,
+            kind: StorageIssueKind::InvalidFormat,
+            file_name: file.file_name().to_string(),
+            reason: format!(
+                "JSON does not match the expected Sklad format (line {}, column {})",
+                error.line(),
+                error.column()
+            ),
+        }
+    }
+
+    fn unreadable(file: StorageFile, error: io::Error) -> Self {
+        Self {
+            file,
+            kind: StorageIssueKind::Unreadable,
+            file_name: file.file_name().to_string(),
+            reason: error.to_string(),
+        }
+    }
+
+    fn invalid_reason(file: StorageFile, reason: impl Into<String>) -> Self {
+        Self {
+            file,
+            kind: StorageIssueKind::InvalidFormat,
+            file_name: file.file_name().to_string(),
+            reason: reason.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for StorageIssue {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let description = match self.kind {
+            StorageIssueKind::InvalidFormat => "has an invalid format",
+            StorageIssueKind::Unreadable => "could not be read",
+        };
+        write!(
+            formatter,
+            "{} {}: {}",
+            self.file_name, description, self.reason
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageStatus {
+    pub data_issue: Option<StorageIssue>,
+    pub settings_issue: Option<StorageIssue>,
+    pub newest_valid_backup: Option<BackupInfo>,
+    pub has_encrypted_secrets: bool,
+}
 
 pub struct DataManager {
     pub file_path: PathBuf,
@@ -36,16 +125,16 @@ impl DataManager {
         }
     }
 
-    pub fn load_data(&self) -> Vec<Node> {
+    pub fn load_data(&self) -> Result<Vec<Node>, StorageIssue> {
         if !self.file_path.exists() {
             let defaults = Self::default_nodes();
             // Save defaults to disk so the file exists for "Open File"
-            let _ = self.save_data(&defaults);
-            return defaults;
+            self.save_data(&defaults)
+                .map_err(|error| StorageIssue::unreadable(StorageFile::Data, error))?;
+            return Ok(defaults);
         }
 
-        let content = fs::read_to_string(&self.file_path).unwrap_or_else(|_| "[]".to_string());
-        serde_json::from_str(&content).unwrap_or_default()
+        Self::read_json(&self.file_path, StorageFile::Data)
     }
 
     pub fn save_data(&self, nodes: &[Node]) -> Result<(), std::io::Error> {
@@ -53,31 +142,87 @@ impl DataManager {
         Self::atomic_write(&self.file_path, content.as_bytes())
     }
 
-    pub fn load_settings(&self) -> crate::models::AppSettings {
-        let settings_path = self.file_path.with_file_name("settings.json");
+    pub fn load_settings(&self) -> Result<crate::models::AppSettings, StorageIssue> {
+        let settings_path = self.settings_path();
         if !settings_path.exists() {
-            return crate::models::AppSettings::default();
+            return Ok(crate::models::AppSettings::default());
         }
 
-        fs::read_to_string(&settings_path)
-            .ok()
-            .and_then(|content| serde_json::from_str(&content).ok())
-            .unwrap_or_default()
+        let settings = Self::read_json(&settings_path, StorageFile::Settings)?;
+        Self::validate_settings(settings)
     }
 
     pub fn save_settings(
         &self,
         settings: &crate::models::AppSettings,
     ) -> Result<(), std::io::Error> {
-        let settings_path = self.file_path.with_file_name("settings.json");
+        let settings_path = self.settings_path();
         let content = serde_json::to_string_pretty(settings)?;
         Self::atomic_write(&settings_path, content.as_bytes())
+    }
+
+    pub fn storage_status(&self) -> StorageStatus {
+        let data_issue = self.data_issue();
+        let settings_issue = self.settings_issue();
+        let newest_valid_backup = self.newest_valid_backup();
+
+        let has_encrypted_secrets = if data_issue.is_none() && self.file_path.exists() {
+            Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data)
+                .map(|nodes| Self::has_encrypted_secrets(&nodes))
+                .unwrap_or(false)
+        } else {
+            newest_valid_backup
+                .as_ref()
+                .and_then(|backup| self.read_backup(&backup.filename).ok())
+                .map(|nodes| Self::has_encrypted_secrets(&nodes))
+                .unwrap_or(false)
+        } || (data_issue.is_some() && settings_issue.is_some());
+
+        StorageStatus {
+            data_issue,
+            settings_issue,
+            newest_valid_backup,
+            has_encrypted_secrets,
+        }
+    }
+
+    pub fn has_storage_issues(&self) -> bool {
+        self.data_issue().is_some() || self.settings_issue().is_some()
+    }
+
+    pub fn reset_invalid_data(&self) -> Result<String, String> {
+        Self::require_invalid_issue(self.data_issue(), StorageFile::Data)?;
+        let quarantined = self.quarantine_file(&self.file_path, "sklad")?;
+        self.save_data(&Self::default_nodes())
+            .map_err(|error| format!("Failed to create fresh data: {}", error))?;
+        Ok(quarantined)
+    }
+
+    pub fn reset_invalid_settings(&self) -> Result<String, String> {
+        Self::require_invalid_issue(self.settings_issue(), StorageFile::Settings)?;
+        let settings_path = self.settings_path();
+        let quarantined = self.quarantine_file(&settings_path, "settings")?;
+        self.save_settings(&crate::models::AppSettings::default())
+            .map_err(|error| format!("Failed to create fresh settings: {}", error))?;
+        Ok(quarantined)
     }
 
     pub fn create_backup(&self) -> Result<(), std::io::Error> {
         if !self.file_path.exists() {
             return Ok(());
         }
+
+        let content = fs::read(&self.file_path)?;
+        serde_json::from_slice::<Vec<Node>>(&content).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Cannot back up invalid sklad.json (line {}, column {})",
+                    error.line(),
+                    error.column()
+                ),
+            )
+        })?;
 
         let mut timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -94,7 +239,6 @@ impl DataManager {
             timestamp += 1;
         };
 
-        let content = fs::read(&self.file_path)?;
         Self::atomic_write(&backup_path, &content)?;
 
         log::info!("Created backup: {:?}", backup_path);
@@ -154,6 +298,12 @@ impl DataManager {
         backups
     }
 
+    pub fn newest_valid_backup(&self) -> Option<BackupInfo> {
+        self.list_backups()
+            .into_iter()
+            .find(|backup| self.read_backup(&backup.filename).is_ok())
+    }
+
     pub fn restore_backup(&self, filename: &str) -> Result<(), String> {
         if Self::backup_timestamp(filename).is_none()
             || filename.contains('/')
@@ -169,14 +319,28 @@ impl DataManager {
         }
 
         let content =
-            fs::read(&backup_path).map_err(|e| format!("Failed to read backup: {}", e))?;
+            fs::read(&backup_path).map_err(|error| format!("Failed to read backup: {}", error))?;
 
-        serde_json::from_slice::<Vec<Node>>(&content)
-            .map_err(|e| format!("Invalid backup format: {}", e))?;
+        serde_json::from_slice::<Vec<Node>>(&content).map_err(|error| {
+            format!(
+                "Invalid backup format at line {}, column {}",
+                error.line(),
+                error.column()
+            )
+        })?;
 
         if self.file_path.exists() {
-            self.create_backup()
-                .map_err(|e| format!("Failed to preserve current data: {}", e))?;
+            match Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data) {
+                Ok(_) => self
+                    .create_backup()
+                    .map_err(|e| format!("Failed to preserve current data: {}", e))?,
+                Err(issue) if issue.kind == StorageIssueKind::InvalidFormat => {
+                    self.quarantine_file(&self.file_path, "sklad")?;
+                }
+                Err(issue) => {
+                    return Err(format!("Failed to preserve current data: {}", issue));
+                }
+            }
         }
 
         Self::atomic_write(&self.file_path, &content)
@@ -192,6 +356,123 @@ impl DataManager {
             .strip_suffix(".json")?
             .parse::<i64>()
             .ok()
+    }
+
+    fn settings_path(&self) -> PathBuf {
+        self.file_path.with_file_name("settings.json")
+    }
+
+    fn data_issue(&self) -> Option<StorageIssue> {
+        if !self.file_path.exists() {
+            return None;
+        }
+        Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data).err()
+    }
+
+    fn settings_issue(&self) -> Option<StorageIssue> {
+        let settings_path = self.settings_path();
+        if !settings_path.exists() {
+            return None;
+        }
+        self.load_settings().err()
+    }
+
+    fn read_json<T: DeserializeOwned>(
+        path: &Path,
+        storage_file: StorageFile,
+    ) -> Result<T, StorageIssue> {
+        let content =
+            fs::read(path).map_err(|error| StorageIssue::unreadable(storage_file, error))?;
+        serde_json::from_slice(&content).map_err(|error| StorageIssue::invalid(storage_file, error))
+    }
+
+    fn validate_settings(
+        settings: crate::models::AppSettings,
+    ) -> Result<crate::models::AppSettings, StorageIssue> {
+        if settings.security.master_password_enabled
+            && (settings.security.password_hash.is_none()
+                || settings.security.derivation_salt.is_none())
+        {
+            return Err(StorageIssue::invalid_reason(
+                StorageFile::Settings,
+                "Vault settings are incomplete",
+            ));
+        }
+
+        Ok(settings)
+    }
+
+    fn read_backup(&self, filename: &str) -> Result<Vec<Node>, String> {
+        if Self::backup_timestamp(filename).is_none()
+            || filename.contains('/')
+            || filename.contains('\\')
+        {
+            return Err("Invalid backup filename".to_string());
+        }
+
+        let content = fs::read(self.backups_dir.join(filename))
+            .map_err(|error| format!("Failed to read backup: {}", error))?;
+        serde_json::from_slice(&content).map_err(|error| {
+            format!(
+                "Invalid backup format at line {}, column {}",
+                error.line(),
+                error.column()
+            )
+        })
+    }
+
+    fn require_invalid_issue(
+        issue: Option<StorageIssue>,
+        storage_file: StorageFile,
+    ) -> Result<(), String> {
+        match issue {
+            Some(issue) if issue.kind == StorageIssueKind::InvalidFormat => Ok(()),
+            Some(issue) => Err(format!(
+                "{} cannot be quarantined automatically: {}",
+                issue.file_name, issue.reason
+            )),
+            None => Err(format!(
+                "{} is valid; recovery is not required",
+                storage_file.file_name()
+            )),
+        }
+    }
+
+    fn quarantine_file(&self, source: &Path, base_name: &str) -> Result<String, String> {
+        let content = fs::read(source)
+            .map_err(|error| format!("Failed to read file for quarantine: {}", error))?;
+        let mut timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        let quarantine_path = loop {
+            let candidate =
+                source.with_file_name(format!("{}.corrupt_{}.json", base_name, timestamp));
+            if !candidate.exists() {
+                break candidate;
+            }
+            timestamp += 1;
+        };
+
+        Self::atomic_write(&quarantine_path, &content)
+            .map_err(|error| format!("Failed to create quarantine copy: {}", error))?;
+
+        quarantine_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_owned)
+            .ok_or_else(|| "Failed to resolve quarantine filename".to_string())
+    }
+
+    fn has_encrypted_secrets(nodes: &[Node]) -> bool {
+        nodes.iter().any(|node| {
+            node.encrypted_value.is_some()
+                || node
+                    .children
+                    .as_deref()
+                    .is_some_and(Self::has_encrypted_secrets)
+        })
     }
 
     fn atomic_write(path: &Path, content: &[u8]) -> io::Result<()> {
@@ -246,8 +527,8 @@ impl DataManager {
 
 #[cfg(test)]
 mod tests {
-    use super::DataManager;
-    use crate::models::{Node, NodeType};
+    use super::{DataManager, StorageIssueKind};
+    use crate::models::{AppSettings, Node, NodeType};
 
     fn snippet(label: &str) -> Node {
         Node {
@@ -270,7 +551,7 @@ mod tests {
 
         manager.save_data(&[snippet("saved")]).unwrap();
 
-        assert_eq!(manager.load_data()[0].label, "saved");
+        assert_eq!(manager.load_data().unwrap()[0].label, "saved");
         let app_entries = std::fs::read_dir(manager.file_path.parent().unwrap()).unwrap();
         assert!(app_entries
             .filter_map(Result::ok)
@@ -302,7 +583,7 @@ mod tests {
 
         manager.restore_backup(&old_backup).unwrap();
 
-        assert_eq!(manager.load_data()[0].label, "old");
+        assert_eq!(manager.load_data().unwrap()[0].label, "old");
         let safety_backup = &manager.list_backups()[0];
         let safety_content =
             std::fs::read(manager.backups_dir.join(&safety_backup.filename)).unwrap();
@@ -320,8 +601,8 @@ mod tests {
 
         let error = manager.restore_backup("sklad_backup_123.json").unwrap_err();
 
-        assert!(error.starts_with("Invalid backup format:"));
-        assert_eq!(manager.load_data()[0].label, "current");
+        assert!(error.starts_with("Invalid backup format"));
+        assert_eq!(manager.load_data().unwrap()[0].label, "current");
     }
 
     #[test]
@@ -337,5 +618,211 @@ mod tests {
             manager.restore_backup("..\\sklad_backup_123.json"),
             Err("Invalid backup filename".to_string())
         );
+    }
+
+    #[test]
+    fn missing_data_is_initialized_as_a_first_run() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+
+        let nodes = manager.load_data().unwrap();
+
+        assert_eq!(nodes[0].label, "Welcome to Sklad");
+        assert!(manager.file_path.exists());
+    }
+
+    #[test]
+    fn invalid_data_is_reported_without_being_replaced() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let invalid_content = b"{not valid json";
+        std::fs::write(&manager.file_path, invalid_content).unwrap();
+
+        let issue = manager.load_data().unwrap_err();
+
+        assert_eq!(issue.kind, StorageIssueKind::InvalidFormat);
+        assert_eq!(std::fs::read(&manager.file_path).unwrap(), invalid_content);
+        assert!(manager.list_backups().is_empty());
+    }
+
+    #[test]
+    fn invalid_data_diagnostics_do_not_include_file_values() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let sensitive_marker = "do-not-log-this-value";
+        let content = format!(
+            r#"[{{"id":"1","type":"{}","label":"label","parentId":null,"createdAt":0}}]"#,
+            sensitive_marker
+        );
+        std::fs::write(&manager.file_path, content).unwrap();
+
+        let issue = manager.load_data().unwrap_err();
+
+        assert!(!issue.reason.contains(sensitive_marker));
+        assert!(!issue.to_string().contains(sensitive_marker));
+    }
+
+    #[test]
+    fn resetting_invalid_data_preserves_an_exact_quarantine_copy() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let invalid_content = b"[invalid data]";
+        std::fs::write(&manager.file_path, invalid_content).unwrap();
+
+        let quarantine_filename = manager.reset_invalid_data().unwrap();
+
+        let quarantine_path = manager.file_path.with_file_name(quarantine_filename);
+        assert_eq!(std::fs::read(quarantine_path).unwrap(), invalid_content);
+        assert_eq!(manager.load_data().unwrap()[0].label, "Welcome to Sklad");
+    }
+
+    #[test]
+    fn restore_quarantines_invalid_current_data_before_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let invalid_content = b"not json";
+        std::fs::write(&manager.file_path, invalid_content).unwrap();
+        let backup_filename = "sklad_backup_123.json";
+        let backup_content = serde_json::to_vec(&vec![snippet("recovered")]).unwrap();
+        std::fs::write(manager.backups_dir.join(backup_filename), backup_content).unwrap();
+
+        manager.restore_backup(backup_filename).unwrap();
+
+        assert_eq!(manager.load_data().unwrap()[0].label, "recovered");
+        let quarantine = std::fs::read_dir(manager.file_path.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .find(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("sklad.corrupt_")
+            })
+            .unwrap();
+        assert_eq!(std::fs::read(quarantine.path()).unwrap(), invalid_content);
+    }
+
+    #[test]
+    fn newest_valid_backup_skips_a_newer_invalid_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        std::fs::write(
+            manager.backups_dir.join("sklad_backup_123.json"),
+            serde_json::to_vec(&vec![snippet("valid")]).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            manager.backups_dir.join("sklad_backup_124.json"),
+            b"invalid",
+        )
+        .unwrap();
+
+        let backup = manager.newest_valid_backup().unwrap();
+
+        assert_eq!(backup.filename, "sklad_backup_123.json");
+    }
+
+    #[test]
+    fn invalid_data_is_not_copied_into_normal_backups() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        std::fs::write(&manager.file_path, b"invalid").unwrap();
+
+        let error = manager.create_backup().unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(manager.list_backups().is_empty());
+    }
+
+    #[test]
+    fn older_settings_with_missing_fields_remain_compatible() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        std::fs::write(
+            manager.settings_path(),
+            br#"{
+                "theme":"dark",
+                "security":{
+                    "lockTimeout":300000,
+                    "clearClipboard":false,
+                    "masterPasswordEnabled":false,
+                    "passwordHash":null,
+                    "derivationSalt":null
+                },
+                "notificationsEnabled":true
+            }"#,
+        )
+        .unwrap();
+
+        let settings = manager.load_settings().unwrap();
+
+        assert_eq!(settings.theme, "dark");
+        assert!(!settings.security.master_password_enabled);
+        assert_eq!(settings.auto_backup_count, 5);
+    }
+
+    #[test]
+    fn incomplete_vault_settings_require_recovery() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        std::fs::write(
+            manager.settings_path(),
+            br#"{
+                "theme":"dark",
+                "security":{
+                    "lockTimeout":300000,
+                    "clearClipboard":false,
+                    "masterPasswordEnabled":true,
+                    "passwordHash":"hash",
+                    "derivationSalt":null
+                },
+                "notificationsEnabled":true
+            }"#,
+        )
+        .unwrap();
+
+        let issue = manager.load_settings().unwrap_err();
+
+        assert_eq!(issue.kind, StorageIssueKind::InvalidFormat);
+        assert_eq!(issue.reason, "Vault settings are incomplete");
+    }
+
+    #[test]
+    fn resetting_invalid_settings_preserves_an_exact_quarantine_copy() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let invalid_content = b"{invalid settings";
+        std::fs::write(manager.settings_path(), invalid_content).unwrap();
+
+        let issue = manager.load_settings().unwrap_err();
+        assert_eq!(issue.kind, StorageIssueKind::InvalidFormat);
+        assert_eq!(
+            std::fs::read(manager.settings_path()).unwrap(),
+            invalid_content
+        );
+
+        let quarantine_filename = manager.reset_invalid_settings().unwrap();
+        let quarantine_path = manager.file_path.with_file_name(quarantine_filename);
+        assert_eq!(std::fs::read(quarantine_path).unwrap(), invalid_content);
+        assert_eq!(
+            manager.load_settings().unwrap().theme,
+            AppSettings::default().theme
+        );
+    }
+
+    #[test]
+    fn unreadable_data_is_not_replaced_by_recovery() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        std::fs::create_dir(&manager.file_path).unwrap();
+
+        let status = manager.storage_status();
+
+        assert_eq!(
+            status.data_issue.unwrap().kind,
+            StorageIssueKind::Unreadable
+        );
+        assert!(manager.reset_invalid_data().is_err());
+        assert!(manager.file_path.is_dir());
     }
 }

--- a/src-tauri/src/data_manager.rs
+++ b/src-tauri/src/data_manager.rs
@@ -27,6 +27,7 @@ impl StorageFile {
 pub enum StorageIssueKind {
     InvalidFormat,
     Unreadable,
+    VaultMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -69,6 +70,15 @@ impl StorageIssue {
             reason: reason.into(),
         }
     }
+
+    fn vault_metadata(reason: impl Into<String>) -> Self {
+        Self {
+            file: StorageFile::Settings,
+            kind: StorageIssueKind::VaultMetadata,
+            file_name: StorageFile::Settings.file_name().to_string(),
+            reason: reason.into(),
+        }
+    }
 }
 
 impl std::fmt::Display for StorageIssue {
@@ -76,6 +86,7 @@ impl std::fmt::Display for StorageIssue {
         let description = match self.kind {
             StorageIssueKind::InvalidFormat => "has an invalid format",
             StorageIssueKind::Unreadable => "could not be read",
+            StorageIssueKind::VaultMetadata => "has missing or inconsistent vault metadata",
         };
         write!(
             formatter,
@@ -92,6 +103,15 @@ pub struct StorageStatus {
     pub settings_issue: Option<StorageIssue>,
     pub newest_valid_backup: Option<BackupInfo>,
     pub has_encrypted_secrets: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultRecoveryResult {
+    pub removed_secret_count: usize,
+    pub data_recovery_copy: Option<String>,
+    pub settings_recovery_copy: Option<String>,
+    pub restored_from_backup: Option<String>,
 }
 
 pub struct DataManager {
@@ -163,7 +183,7 @@ impl DataManager {
 
     pub fn storage_status(&self) -> StorageStatus {
         let data_issue = self.data_issue();
-        let settings_issue = self.settings_issue();
+        let mut settings_issue = self.settings_issue();
         let newest_valid_backup = self.newest_valid_backup();
 
         let has_encrypted_secrets = if data_issue.is_none() && self.file_path.exists() {
@@ -178,6 +198,21 @@ impl DataManager {
                 .unwrap_or(false)
         } || (data_issue.is_some() && settings_issue.is_some());
 
+        if settings_issue.is_none() && has_encrypted_secrets {
+            if !self.settings_path().exists() {
+                settings_issue = Some(StorageIssue::vault_metadata(
+                    "Encrypted snippets exist, but settings.json is missing",
+                ));
+            } else if self
+                .load_settings()
+                .is_ok_and(|settings| !settings.security.master_password_enabled)
+            {
+                settings_issue = Some(StorageIssue::vault_metadata(
+                    "Encrypted snippets exist, but the vault is disabled in settings.json",
+                ));
+            }
+        }
+
         StorageStatus {
             data_issue,
             settings_issue,
@@ -187,7 +222,16 @@ impl DataManager {
     }
 
     pub fn has_storage_issues(&self) -> bool {
-        self.data_issue().is_some() || self.settings_issue().is_some()
+        let status = self.storage_status();
+        status.data_issue.is_some() || status.settings_issue.is_some()
+    }
+
+    pub fn ensure_storage_healthy(&self) -> Result<(), String> {
+        let status = self.storage_status();
+        status
+            .data_issue
+            .or(status.settings_issue)
+            .map_or(Ok(()), |issue| Err(issue.to_string()))
     }
 
     pub fn reset_invalid_data(&self) -> Result<String, String> {
@@ -199,12 +243,81 @@ impl DataManager {
     }
 
     pub fn reset_invalid_settings(&self) -> Result<String, String> {
-        Self::require_invalid_issue(self.settings_issue(), StorageFile::Settings)?;
+        let status = self.storage_status();
+        if status.has_encrypted_secrets {
+            return Err(
+                "Encrypted snippets may depend on these settings; use vault recovery instead"
+                    .to_string(),
+            );
+        }
+        Self::require_invalid_issue(status.settings_issue, StorageFile::Settings)?;
         let settings_path = self.settings_path();
         let quarantined = self.quarantine_file(&settings_path, "settings")?;
         self.save_settings(&crate::models::AppSettings::default())
             .map_err(|error| format!("Failed to create fresh settings: {}", error))?;
         Ok(quarantined)
+    }
+
+    pub fn discard_unrecoverable_vault_data(&self) -> Result<VaultRecoveryResult, String> {
+        let status = self.storage_status();
+        if status.data_issue.is_some() {
+            return Err("Recover snippet data before resetting the unavailable vault".to_string());
+        }
+        if !status.has_encrypted_secrets {
+            return Err("No encrypted snippets require vault recovery".to_string());
+        }
+
+        let settings_issue = status
+            .settings_issue
+            .ok_or_else(|| "Vault metadata is healthy; recovery is not required".to_string())?;
+        if !matches!(
+            settings_issue.kind,
+            StorageIssueKind::InvalidFormat | StorageIssueKind::VaultMetadata
+        ) {
+            return Err(format!(
+                "{} cannot be recovered automatically: {}",
+                settings_issue.file_name, settings_issue.reason
+            ));
+        }
+
+        let (mut nodes, restored_from_backup) = if self.file_path.exists() {
+            (
+                Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data)
+                    .map_err(|issue| issue.to_string())?,
+                None,
+            )
+        } else {
+            let backup = status
+                .newest_valid_backup
+                .ok_or_else(|| "No valid snippet data is available for recovery".to_string())?;
+            let nodes = self.read_backup(&backup.filename)?;
+            (nodes, Some(backup.filename))
+        };
+
+        let removed_secret_count = Self::remove_unrecoverable_secrets(&mut nodes);
+        let data_recovery_copy = if self.file_path.exists() {
+            Some(self.preserve_file(&self.file_path, "sklad", "vault_recovery")?)
+        } else {
+            None
+        };
+        let settings_path = self.settings_path();
+        let settings_recovery_copy = if settings_path.exists() {
+            Some(self.preserve_file(&settings_path, "settings", "vault_recovery")?)
+        } else {
+            None
+        };
+
+        self.save_settings(&crate::models::AppSettings::default())
+            .map_err(|error| format!("Failed to reset vault settings: {}", error))?;
+        self.save_data(&nodes)
+            .map_err(|error| format!("Failed to save recovered snippet data: {}", error))?;
+
+        Ok(VaultRecoveryResult {
+            removed_secret_count,
+            data_recovery_copy,
+            settings_recovery_copy,
+            restored_from_backup,
+        })
     }
 
     pub fn create_backup(&self) -> Result<(), std::io::Error> {
@@ -439,8 +552,17 @@ impl DataManager {
     }
 
     fn quarantine_file(&self, source: &Path, base_name: &str) -> Result<String, String> {
+        self.preserve_file(source, base_name, "corrupt")
+    }
+
+    fn preserve_file(
+        &self,
+        source: &Path,
+        base_name: &str,
+        reason: &str,
+    ) -> Result<String, String> {
         let content = fs::read(source)
-            .map_err(|error| format!("Failed to read file for quarantine: {}", error))?;
+            .map_err(|error| format!("Failed to read source file for preservation: {}", error))?;
         let mut timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -448,7 +570,7 @@ impl DataManager {
 
         let quarantine_path = loop {
             let candidate =
-                source.with_file_name(format!("{}.corrupt_{}.json", base_name, timestamp));
+                source.with_file_name(format!("{}.{}_{}.json", base_name, reason, timestamp));
             if !candidate.exists() {
                 break candidate;
             }
@@ -456,7 +578,7 @@ impl DataManager {
         };
 
         Self::atomic_write(&quarantine_path, &content)
-            .map_err(|error| format!("Failed to create quarantine copy: {}", error))?;
+            .map_err(|error| format!("Failed to create recovery copy: {}", error))?;
 
         quarantine_path
             .file_name()
@@ -473,6 +595,20 @@ impl DataManager {
                     .as_deref()
                     .is_some_and(Self::has_encrypted_secrets)
         })
+    }
+
+    fn remove_unrecoverable_secrets(nodes: &mut Vec<Node>) -> usize {
+        let original_len = nodes.len();
+        nodes.retain(|node| !node.is_secret.unwrap_or(false) && node.encrypted_value.is_none());
+        let mut removed = original_len - nodes.len();
+
+        for node in nodes {
+            if let Some(children) = &mut node.children {
+                removed += Self::remove_unrecoverable_secrets(children);
+            }
+        }
+
+        removed
     }
 
     fn atomic_write(path: &Path, content: &[u8]) -> io::Result<()> {
@@ -541,6 +677,20 @@ mod tests {
             value: Some(label.to_string()),
             encrypted_value: None,
             is_secret: Some(false),
+        }
+    }
+
+    fn encrypted_snippet(label: &str) -> Node {
+        Node {
+            id: format!("{}-secret-id", label),
+            node_type: NodeType::Snippet,
+            label: label.to_string(),
+            parent_id: None,
+            created_at: 0,
+            children: None,
+            value: None,
+            encrypted_value: Some("nonce:ciphertext".to_string()),
+            is_secret: Some(true),
         }
     }
 
@@ -763,28 +913,173 @@ mod tests {
 
     #[test]
     fn incomplete_vault_settings_require_recovery() {
+        for (password_hash, derivation_salt) in [(None, Some("salt")), (Some("hash"), None)] {
+            let directory = tempfile::tempdir().unwrap();
+            let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+            let mut settings = AppSettings::default();
+            settings.security.master_password_enabled = true;
+            settings.security.password_hash = password_hash.map(str::to_string);
+            settings.security.derivation_salt = derivation_salt.map(str::to_string);
+            manager.save_settings(&settings).unwrap();
+
+            let issue = manager.load_settings().unwrap_err();
+
+            assert_eq!(issue.kind, StorageIssueKind::InvalidFormat);
+            assert_eq!(issue.reason, "Vault settings are incomplete");
+        }
+    }
+
+    #[test]
+    fn missing_settings_with_encrypted_data_requires_recovery_without_writing_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let original_data = serde_json::to_vec(&vec![encrypted_snippet("secret")]).unwrap();
+        std::fs::write(&manager.file_path, &original_data).unwrap();
+
+        let status = manager.storage_status();
+
+        let issue = status.settings_issue.unwrap();
+        assert_eq!(issue.kind, StorageIssueKind::VaultMetadata);
+        assert_eq!(std::fs::read(&manager.file_path).unwrap(), original_data);
+        assert!(!manager.settings_path().exists());
+        assert!(manager.has_storage_issues());
+    }
+
+    #[test]
+    fn missing_settings_with_an_encrypted_backup_requires_recovery_without_creating_data() {
         let directory = tempfile::tempdir().unwrap();
         let manager = DataManager::from_app_data_dir(directory.path().join("app"));
         std::fs::write(
-            manager.settings_path(),
-            br#"{
-                "theme":"dark",
-                "security":{
-                    "lockTimeout":300000,
-                    "clearClipboard":false,
-                    "masterPasswordEnabled":true,
-                    "passwordHash":"hash",
-                    "derivationSalt":null
-                },
-                "notificationsEnabled":true
-            }"#,
+            manager.backups_dir.join("sklad_backup_123.json"),
+            serde_json::to_vec(&vec![encrypted_snippet("backup-secret")]).unwrap(),
         )
         .unwrap();
 
-        let issue = manager.load_settings().unwrap_err();
+        let status = manager.storage_status();
 
-        assert_eq!(issue.kind, StorageIssueKind::InvalidFormat);
-        assert_eq!(issue.reason, "Vault settings are incomplete");
+        assert_eq!(
+            status.settings_issue.unwrap().kind,
+            StorageIssueKind::VaultMetadata
+        );
+        assert!(!manager.file_path.exists());
+        assert!(!manager.settings_path().exists());
+    }
+
+    #[test]
+    fn disabled_vault_with_encrypted_data_requires_recovery() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        manager
+            .save_data(&[encrypted_snippet("disabled-secret")])
+            .unwrap();
+        manager.save_settings(&AppSettings::default()).unwrap();
+
+        let status = manager.storage_status();
+
+        let issue = status.settings_issue.unwrap();
+        assert_eq!(issue.kind, StorageIssueKind::VaultMetadata);
+        assert!(issue.reason.contains("vault is disabled"));
+    }
+
+    #[test]
+    fn complete_enabled_vault_metadata_keeps_encrypted_data_healthy() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        manager
+            .save_data(&[encrypted_snippet("healthy-secret")])
+            .unwrap();
+        let mut settings = AppSettings::default();
+        settings.security.master_password_enabled = true;
+        settings.security.password_hash = Some("hash".to_string());
+        settings.security.derivation_salt = Some("salt".to_string());
+        manager.save_settings(&settings).unwrap();
+
+        let status = manager.storage_status();
+
+        assert!(status.data_issue.is_none());
+        assert!(status.settings_issue.is_none());
+        assert!(status.has_encrypted_secrets);
+        assert!(!manager.has_storage_issues());
+    }
+
+    #[test]
+    fn vault_recovery_preserves_sources_and_removes_only_unavailable_secrets() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let mut inconsistent_secret = encrypted_snippet("inconsistent-secret");
+        inconsistent_secret.is_secret = Some(false);
+        let original_nodes = vec![
+            snippet("public"),
+            encrypted_snippet("secret"),
+            inconsistent_secret,
+        ];
+        let original_data = serde_json::to_vec_pretty(&original_nodes).unwrap();
+        std::fs::write(&manager.file_path, &original_data).unwrap();
+        let original_settings = serde_json::to_vec_pretty(&AppSettings::default()).unwrap();
+        std::fs::write(manager.settings_path(), &original_settings).unwrap();
+
+        let result = manager.discard_unrecoverable_vault_data().unwrap();
+
+        assert_eq!(result.removed_secret_count, 2);
+        assert!(result.restored_from_backup.is_none());
+        let data_copy = manager
+            .file_path
+            .with_file_name(result.data_recovery_copy.unwrap());
+        let settings_copy = manager
+            .file_path
+            .with_file_name(result.settings_recovery_copy.unwrap());
+        assert_eq!(std::fs::read(data_copy).unwrap(), original_data);
+        assert_eq!(std::fs::read(settings_copy).unwrap(), original_settings);
+        let recovered = manager.load_data().unwrap();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].label, "public");
+        assert!(!manager.has_storage_issues());
+    }
+
+    #[test]
+    fn vault_recovery_can_keep_public_data_from_an_encrypted_backup() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let backup_filename = "sklad_backup_123.json";
+        let backup_content = serde_json::to_vec(&vec![
+            snippet("backup-public"),
+            encrypted_snippet("backup-secret"),
+        ])
+        .unwrap();
+        std::fs::write(manager.backups_dir.join(backup_filename), &backup_content).unwrap();
+
+        let result = manager.discard_unrecoverable_vault_data().unwrap();
+
+        assert_eq!(
+            result.restored_from_backup.as_deref(),
+            Some(backup_filename)
+        );
+        assert_eq!(result.removed_secret_count, 1);
+        assert_eq!(manager.load_data().unwrap()[0].label, "backup-public");
+        assert_eq!(
+            std::fs::read(manager.backups_dir.join(backup_filename)).unwrap(),
+            backup_content
+        );
+        assert!(!manager.has_storage_issues());
+    }
+
+    #[test]
+    fn invalid_settings_with_encrypted_data_cannot_be_reset_without_vault_recovery() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        manager
+            .save_data(&[encrypted_snippet("protected")])
+            .unwrap();
+        let invalid_settings = b"{invalid settings";
+        std::fs::write(manager.settings_path(), invalid_settings).unwrap();
+
+        let error = manager.reset_invalid_settings().unwrap_err();
+
+        assert!(error.contains("use vault recovery"));
+        assert_eq!(
+            std::fs::read(manager.settings_path()).unwrap(),
+            invalid_settings
+        );
     }
 
     #[test]

--- a/src-tauri/src/data_manager.rs
+++ b/src-tauri/src/data_manager.rs
@@ -1,10 +1,70 @@
-use crate::models::{BackupInfo, Node};
-use serde::{de::DeserializeOwned, Serialize};
+use crate::models::{AppSettings, BackupInfo, Node};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager, Runtime};
 use tempfile::NamedTempFile;
+
+const DATA_FILE_VERSION: u32 = 1;
+const DERIVATION_SALT_BYTES: usize = 16;
+
+fn derivation_salt_is_valid(salt: &str) -> bool {
+    hex::decode(salt).is_ok_and(|bytes| bytes.len() == DERIVATION_SALT_BYTES)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultMetadata {
+    password_hash: String,
+    derivation_salt: String,
+}
+
+impl VaultMetadata {
+    fn from_settings(settings: &AppSettings) -> Option<Self> {
+        if !settings.security.master_password_enabled {
+            return None;
+        }
+
+        Some(Self {
+            password_hash: settings.security.password_hash.clone()?,
+            derivation_salt: settings.security.derivation_salt.clone()?,
+        })
+    }
+
+    fn apply_to_settings(&self, settings: &mut AppSettings) {
+        settings.security.master_password_enabled = true;
+        settings.security.password_hash = Some(self.password_hash.clone());
+        settings.security.derivation_salt = Some(self.derivation_salt.clone());
+    }
+
+    fn is_complete(&self) -> bool {
+        !self.password_hash.is_empty() && derivation_salt_is_valid(&self.derivation_salt)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VersionedData {
+    version: u32,
+    nodes: Vec<Node>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    vault_metadata: Option<VaultMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PersistedData {
+    Legacy(Vec<Node>),
+    Versioned(VersionedData),
+}
+
+#[derive(Debug, Clone)]
+struct DataContents {
+    nodes: Vec<Node>,
+    vault_metadata: Option<VaultMetadata>,
+    is_versioned: bool,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -102,7 +162,9 @@ pub struct StorageStatus {
     pub data_issue: Option<StorageIssue>,
     pub settings_issue: Option<StorageIssue>,
     pub newest_valid_backup: Option<BackupInfo>,
+    pub newest_vault_backup: Option<BackupInfo>,
     pub has_encrypted_secrets: bool,
+    pub vault_metadata_recoverable: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -154,12 +216,28 @@ impl DataManager {
             return Ok(defaults);
         }
 
-        Self::read_json(&self.file_path, StorageFile::Data)
+        Self::read_data_file(&self.file_path, StorageFile::Data).map(|contents| contents.nodes)
     }
 
     pub fn save_data(&self, nodes: &[Node]) -> Result<(), std::io::Error> {
-        let content = serde_json::to_string_pretty(nodes)?;
-        Self::atomic_write(&self.file_path, content.as_bytes())
+        let vault_metadata = if Self::has_encrypted_secrets(nodes) {
+            let settings = self.load_settings().map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Cannot save encrypted snippets: {}", error),
+                )
+            })?;
+            Some(VaultMetadata::from_settings(&settings).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Cannot save encrypted snippets without complete vault metadata",
+                )
+            })?)
+        } else {
+            None
+        };
+
+        self.save_data_with_metadata(nodes, vault_metadata.as_ref())
     }
 
     pub fn load_settings(&self) -> Result<crate::models::AppSettings, StorageIssue> {
@@ -177,48 +255,107 @@ impl DataManager {
         settings: &crate::models::AppSettings,
     ) -> Result<(), std::io::Error> {
         let settings_path = self.settings_path();
-        let content = serde_json::to_string_pretty(settings)?;
+        let validated = Self::validate_settings(settings.clone()).map_err(|issue| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Cannot save invalid settings: {}", issue.reason),
+            )
+        })?;
+        let content = serde_json::to_string_pretty(&validated)?;
         Self::atomic_write(&settings_path, content.as_bytes())
     }
 
     pub fn storage_status(&self) -> StorageStatus {
-        let data_issue = self.data_issue();
+        let active_data = if self.file_path.exists() {
+            Some(Self::read_data_file(&self.file_path, StorageFile::Data))
+        } else {
+            None
+        };
+        let data_issue = active_data
+            .as_ref()
+            .and_then(|result| result.as_ref().err().cloned());
         let mut settings_issue = self.settings_issue();
         let newest_valid_backup = self.newest_valid_backup();
+        let newest_vault_backup = self.newest_vault_backup();
 
-        let has_encrypted_secrets = if data_issue.is_none() && self.file_path.exists() {
-            Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data)
-                .map(|nodes| Self::has_encrypted_secrets(&nodes))
-                .unwrap_or(false)
-        } else {
-            newest_valid_backup
+        let active_contents = active_data.as_ref().and_then(|result| result.as_ref().ok());
+        let fallback_contents = if active_contents.is_none() {
+            newest_vault_backup
                 .as_ref()
+                .or(newest_valid_backup.as_ref())
                 .and_then(|backup| self.read_backup(&backup.filename).ok())
-                .map(|nodes| Self::has_encrypted_secrets(&nodes))
-                .unwrap_or(false)
-        } || (data_issue.is_some() && settings_issue.is_some());
+        } else {
+            None
+        };
+        let relevant_contents = active_contents.or(fallback_contents.as_ref());
+
+        let has_encrypted_secrets = relevant_contents
+            .is_some_and(|contents| Self::has_encrypted_secrets(&contents.nodes))
+            || (data_issue.is_some() && settings_issue.is_some());
+
+        let active_vault_metadata = active_contents
+            .filter(|contents| Self::has_encrypted_secrets(&contents.nodes))
+            .and_then(|contents| contents.vault_metadata.as_ref());
 
         if settings_issue.is_none() && has_encrypted_secrets {
             if !self.settings_path().exists() {
                 settings_issue = Some(StorageIssue::vault_metadata(
                     "Encrypted snippets exist, but settings.json is missing",
                 ));
-            } else if self
-                .load_settings()
-                .is_ok_and(|settings| !settings.security.master_password_enabled)
-            {
-                settings_issue = Some(StorageIssue::vault_metadata(
-                    "Encrypted snippets exist, but the vault is disabled in settings.json",
-                ));
+            } else if let Ok(settings) = self.load_settings() {
+                if !settings.security.master_password_enabled {
+                    settings_issue = Some(StorageIssue::vault_metadata(
+                        "Encrypted snippets exist, but the vault is disabled in settings.json",
+                    ));
+                } else if active_vault_metadata.is_some_and(|metadata| {
+                    VaultMetadata::from_settings(&settings).as_ref() != Some(metadata)
+                }) {
+                    settings_issue = Some(StorageIssue::vault_metadata(
+                        "Vault metadata in settings.json does not match the encrypted snippet data",
+                    ));
+                }
             }
         }
+
+        let vault_metadata_recoverable = data_issue.is_none()
+            && settings_issue.is_some()
+            && active_vault_metadata.is_some_and(VaultMetadata::is_complete);
 
         StorageStatus {
             data_issue,
             settings_issue,
             newest_valid_backup,
+            newest_vault_backup,
             has_encrypted_secrets,
+            vault_metadata_recoverable,
         }
+    }
+
+    pub fn ensure_vault_metadata_redundancy(&self) -> Result<bool, String> {
+        if !self.file_path.exists() {
+            return Ok(false);
+        }
+
+        let contents = Self::read_data_file(&self.file_path, StorageFile::Data)
+            .map_err(|issue| issue.to_string())?;
+        if !Self::has_encrypted_secrets(&contents.nodes) {
+            return Ok(false);
+        }
+
+        let settings = self.load_settings().map_err(|issue| issue.to_string())?;
+        let metadata = VaultMetadata::from_settings(&settings)
+            .ok_or_else(|| "Encrypted snippets require complete vault metadata".to_string())?;
+        if contents.is_versioned && contents.vault_metadata.as_ref() == Some(&metadata) {
+            return Ok(false);
+        }
+
+        if !contents.is_versioned {
+            self.preserve_file(&self.file_path, "sklad", "pre_metadata_migration")?;
+        }
+
+        self.save_data_with_metadata(&contents.nodes, Some(&metadata))
+            .map_err(|error| format!("Failed to make vault metadata recoverable: {}", error))?;
+        Ok(true)
     }
 
     pub fn has_storage_issues(&self) -> bool {
@@ -258,6 +395,48 @@ impl DataManager {
         Ok(quarantined)
     }
 
+    pub fn recover_vault_metadata(&self) -> Result<Option<String>, String> {
+        let status = self.storage_status();
+        if status.data_issue.is_some() {
+            return Err("Recover snippet data before restoring vault metadata".to_string());
+        }
+        if !status.vault_metadata_recoverable {
+            return Err("No recoverable vault metadata is available in sklad.json".to_string());
+        }
+
+        let contents = Self::read_data_file(&self.file_path, StorageFile::Data)
+            .map_err(|issue| issue.to_string())?;
+        let metadata = contents
+            .vault_metadata
+            .ok_or_else(|| "sklad.json does not contain vault recovery metadata".to_string())?;
+
+        let settings_path = self.settings_path();
+        let (mut settings, recovery_copy) = if settings_path.exists() {
+            let copy = self.preserve_file(&settings_path, "settings", "vault_recovery")?;
+            let settings = match self.load_settings() {
+                Ok(settings) => settings,
+                Err(issue) if issue.kind == StorageIssueKind::InvalidFormat => {
+                    AppSettings::default()
+                }
+                Err(issue) => {
+                    return Err(format!(
+                        "{} cannot be recovered automatically: {}",
+                        issue.file_name, issue.reason
+                    ));
+                }
+            };
+            (settings, Some(copy))
+        } else {
+            (AppSettings::default(), None)
+        };
+
+        metadata.apply_to_settings(&mut settings);
+        self.save_settings(&settings)
+            .map_err(|error| format!("Failed to restore vault settings: {}", error))?;
+
+        Ok(recovery_copy)
+    }
+
     pub fn discard_unrecoverable_vault_data(&self) -> Result<VaultRecoveryResult, String> {
         let status = self.storage_status();
         if status.data_issue.is_some() {
@@ -282,16 +461,17 @@ impl DataManager {
 
         let (mut nodes, restored_from_backup) = if self.file_path.exists() {
             (
-                Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data)
-                    .map_err(|issue| issue.to_string())?,
+                Self::read_data_file(&self.file_path, StorageFile::Data)
+                    .map_err(|issue| issue.to_string())?
+                    .nodes,
                 None,
             )
         } else {
             let backup = status
                 .newest_valid_backup
                 .ok_or_else(|| "No valid snippet data is available for recovery".to_string())?;
-            let nodes = self.read_backup(&backup.filename)?;
-            (nodes, Some(backup.filename))
+            let contents = self.read_backup(&backup.filename)?;
+            (contents.nodes, Some(backup.filename))
         };
 
         let removed_secret_count = Self::remove_unrecoverable_secrets(&mut nodes);
@@ -325,17 +505,35 @@ impl DataManager {
             return Ok(());
         }
 
-        let content = fs::read(&self.file_path)?;
-        serde_json::from_slice::<Vec<Node>>(&content).map_err(|error| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "Cannot back up invalid sklad.json (line {}, column {})",
-                    error.line(),
-                    error.column()
-                ),
-            )
-        })?;
+        let contents =
+            Self::read_data_file(&self.file_path, StorageFile::Data).map_err(|issue| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Cannot back up invalid sklad.json: {}", issue.reason),
+                )
+            })?;
+        let vault_metadata = if Self::has_encrypted_secrets(&contents.nodes) {
+            match contents.vault_metadata {
+                Some(metadata) => Some(metadata),
+                None => {
+                    let settings = self.load_settings().map_err(|issue| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("Cannot back up encrypted snippets: {}", issue),
+                        )
+                    })?;
+                    Some(VaultMetadata::from_settings(&settings).ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Cannot back up encrypted snippets without complete vault metadata",
+                        )
+                    })?)
+                }
+            }
+        } else {
+            None
+        };
+        let content = Self::serialize_data(&contents.nodes, vault_metadata.as_ref())?;
 
         let mut timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -401,6 +599,9 @@ impl DataManager {
                             filename: filename.to_string(),
                             timestamp,
                             size,
+                            has_vault_metadata: self
+                                .read_backup(filename)
+                                .is_ok_and(|contents| contents.vault_metadata.is_some()),
                         });
                     }
                 }
@@ -417,6 +618,14 @@ impl DataManager {
             .find(|backup| self.read_backup(&backup.filename).is_ok())
     }
 
+    pub fn newest_vault_backup(&self) -> Option<BackupInfo> {
+        self.list_backups().into_iter().find(|backup| {
+            self.read_backup(&backup.filename).is_ok_and(|contents| {
+                contents.vault_metadata.is_some() && Self::has_encrypted_secrets(&contents.nodes)
+            })
+        })
+    }
+
     pub fn restore_backup(&self, filename: &str) -> Result<(), String> {
         if Self::backup_timestamp(filename).is_none()
             || filename.contains('/')
@@ -431,22 +640,52 @@ impl DataManager {
             return Err("Backup file not found".to_string());
         }
 
-        let content =
-            fs::read(&backup_path).map_err(|error| format!("Failed to read backup: {}", error))?;
+        let mut backup = self.read_backup(filename)?;
+        if Self::has_encrypted_secrets(&backup.nodes) && backup.vault_metadata.is_none() {
+            let settings = self.load_settings().map_err(|issue| {
+                format!("This legacy backup needs the original settings: {}", issue)
+            })?;
+            backup.vault_metadata = Some(VaultMetadata::from_settings(&settings).ok_or_else(|| {
+                "This legacy backup contains encrypted snippets but no recoverable vault metadata"
+                    .to_string()
+            })?);
+        }
 
-        serde_json::from_slice::<Vec<Node>>(&content).map_err(|error| {
-            format!(
-                "Invalid backup format at line {}, column {}",
-                error.line(),
-                error.column()
-            )
-        })?;
+        let target_content = Self::serialize_data(&backup.nodes, backup.vault_metadata.as_ref())
+            .map_err(|error| format!("Failed to prepare backup restore: {}", error))?;
+
+        let target_settings = if let Some(metadata) = &backup.vault_metadata {
+            let mut settings = match self.load_settings() {
+                Ok(settings) => settings,
+                Err(issue) if issue.kind == StorageIssueKind::InvalidFormat => {
+                    AppSettings::default()
+                }
+                Err(issue) => {
+                    return Err(format!(
+                        "{} cannot be recovered automatically: {}",
+                        issue.file_name, issue.reason
+                    ));
+                }
+            };
+            metadata.apply_to_settings(&mut settings);
+            Some(settings)
+        } else {
+            None
+        };
 
         if self.file_path.exists() {
-            match Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data) {
-                Ok(_) => self
-                    .create_backup()
-                    .map_err(|e| format!("Failed to preserve current data: {}", e))?,
+            match Self::read_data_file(&self.file_path, StorageFile::Data) {
+                Ok(_) => {
+                    if let Err(error) = self.create_backup() {
+                        self.preserve_file(&self.file_path, "sklad", "before_restore")
+                            .map_err(|preserve_error| {
+                                format!(
+                                    "Failed to preserve current data: {}; {}",
+                                    error, preserve_error
+                                )
+                            })?;
+                    }
+                }
                 Err(issue) if issue.kind == StorageIssueKind::InvalidFormat => {
                     self.quarantine_file(&self.file_path, "sklad")?;
                 }
@@ -456,8 +695,24 @@ impl DataManager {
             }
         }
 
-        Self::atomic_write(&self.file_path, &content)
+        if target_settings.is_some() {
+            let settings_path = self.settings_path();
+            if settings_path.exists() {
+                self.preserve_file(&settings_path, "settings", "before_restore")?;
+            }
+        }
+
+        Self::atomic_write(&self.file_path, &target_content)
             .map_err(|e| format!("Failed to restore backup: {}", e))?;
+
+        if let Some(settings) = target_settings {
+            self.save_settings(&settings).map_err(|error| {
+                format!(
+                    "Data was restored, but vault settings need recovery: {}",
+                    error
+                )
+            })?;
+        }
 
         log::info!("Restored backup: {:?}", backup_path);
         Ok(())
@@ -479,7 +734,7 @@ impl DataManager {
         if !self.file_path.exists() {
             return None;
         }
-        Self::read_json::<Vec<Node>>(&self.file_path, StorageFile::Data).err()
+        Self::read_data_file(&self.file_path, StorageFile::Data).err()
     }
 
     fn settings_issue(&self) -> Option<StorageIssue> {
@@ -499,6 +754,87 @@ impl DataManager {
         serde_json::from_slice(&content).map_err(|error| StorageIssue::invalid(storage_file, error))
     }
 
+    fn read_data_file(
+        path: &Path,
+        storage_file: StorageFile,
+    ) -> Result<DataContents, StorageIssue> {
+        let content =
+            fs::read(path).map_err(|error| StorageIssue::unreadable(storage_file, error))?;
+        let persisted: PersistedData = serde_json::from_slice(&content)
+            .map_err(|error| StorageIssue::invalid(storage_file, error))?;
+
+        match persisted {
+            PersistedData::Legacy(nodes) => Ok(DataContents {
+                nodes,
+                vault_metadata: None,
+                is_versioned: false,
+            }),
+            PersistedData::Versioned(versioned) => {
+                if versioned.version != DATA_FILE_VERSION {
+                    return Err(StorageIssue::invalid_reason(
+                        storage_file,
+                        format!("Unsupported data format version {}", versioned.version),
+                    ));
+                }
+                if versioned
+                    .vault_metadata
+                    .as_ref()
+                    .is_some_and(|metadata| !metadata.is_complete())
+                {
+                    return Err(StorageIssue::invalid_reason(
+                        storage_file,
+                        "Embedded vault metadata is incomplete",
+                    ));
+                }
+                if Self::has_encrypted_secrets(&versioned.nodes)
+                    && versioned.vault_metadata.is_none()
+                {
+                    return Err(StorageIssue::invalid_reason(
+                        storage_file,
+                        "Versioned encrypted data is missing vault metadata",
+                    ));
+                }
+
+                Ok(DataContents {
+                    nodes: versioned.nodes,
+                    vault_metadata: versioned.vault_metadata,
+                    is_versioned: true,
+                })
+            }
+        }
+    }
+
+    fn serialize_data(
+        nodes: &[Node],
+        vault_metadata: Option<&VaultMetadata>,
+    ) -> Result<Vec<u8>, io::Error> {
+        if Self::has_encrypted_secrets(nodes) {
+            let metadata = vault_metadata.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Encrypted snippets require embedded vault metadata",
+                )
+            })?;
+            serde_json::to_vec_pretty(&VersionedData {
+                version: DATA_FILE_VERSION,
+                nodes: nodes.to_vec(),
+                vault_metadata: Some(metadata.clone()),
+            })
+            .map_err(Into::into)
+        } else {
+            serde_json::to_vec_pretty(nodes).map_err(Into::into)
+        }
+    }
+
+    fn save_data_with_metadata(
+        &self,
+        nodes: &[Node],
+        vault_metadata: Option<&VaultMetadata>,
+    ) -> Result<(), io::Error> {
+        let content = Self::serialize_data(nodes, vault_metadata)?;
+        Self::atomic_write(&self.file_path, &content)
+    }
+
     fn validate_settings(
         settings: crate::models::AppSettings,
     ) -> Result<crate::models::AppSettings, StorageIssue> {
@@ -511,11 +847,35 @@ impl DataManager {
                 "Vault settings are incomplete",
             ));
         }
+        if settings.security.master_password_enabled
+            && settings
+                .security
+                .password_hash
+                .as_deref()
+                .is_some_and(str::is_empty)
+        {
+            return Err(StorageIssue::invalid_reason(
+                StorageFile::Settings,
+                "Vault password verifier is empty",
+            ));
+        }
+        if settings.security.master_password_enabled
+            && settings
+                .security
+                .derivation_salt
+                .as_deref()
+                .is_some_and(|salt| !derivation_salt_is_valid(salt))
+        {
+            return Err(StorageIssue::invalid_reason(
+                StorageFile::Settings,
+                "Vault derivation salt is invalid",
+            ));
+        }
 
         Ok(settings)
     }
 
-    fn read_backup(&self, filename: &str) -> Result<Vec<Node>, String> {
+    fn read_backup(&self, filename: &str) -> Result<DataContents, String> {
         if Self::backup_timestamp(filename).is_none()
             || filename.contains('/')
             || filename.contains('\\')
@@ -523,15 +883,8 @@ impl DataManager {
             return Err("Invalid backup filename".to_string());
         }
 
-        let content = fs::read(self.backups_dir.join(filename))
-            .map_err(|error| format!("Failed to read backup: {}", error))?;
-        serde_json::from_slice(&content).map_err(|error| {
-            format!(
-                "Invalid backup format at line {}, column {}",
-                error.line(),
-                error.column()
-            )
-        })
+        Self::read_data_file(&self.backups_dir.join(filename), StorageFile::Data)
+            .map_err(|issue| format!("Invalid backup: {}", issue.reason))
     }
 
     fn require_invalid_issue(
@@ -666,6 +1019,9 @@ mod tests {
     use super::{DataManager, StorageIssueKind};
     use crate::models::{AppSettings, Node, NodeType};
 
+    const FIRST_VALID_SALT: &str = "00112233445566778899aabbccddeeff";
+    const SECOND_VALID_SALT: &str = "ffeeddccbbaa99887766554433221100";
+
     fn snippet(label: &str) -> Node {
         Node {
             id: format!("{}-id", label),
@@ -692,6 +1048,14 @@ mod tests {
             encrypted_value: Some("nonce:ciphertext".to_string()),
             is_secret: Some(true),
         }
+    }
+
+    fn enabled_vault_settings(password_hash: &str, derivation_salt: &str) -> AppSettings {
+        let mut settings = AppSettings::default();
+        settings.security.master_password_enabled = true;
+        settings.security.password_hash = Some(password_hash.to_string());
+        settings.security.derivation_salt = Some(derivation_salt.to_string());
+        settings
     }
 
     #[test]
@@ -751,7 +1115,7 @@ mod tests {
 
         let error = manager.restore_backup("sklad_backup_123.json").unwrap_err();
 
-        assert!(error.starts_with("Invalid backup format"));
+        assert!(error.starts_with("Invalid backup:"));
         assert_eq!(manager.load_data().unwrap()[0].label, "current");
     }
 
@@ -950,13 +1314,34 @@ mod tests {
             settings.security.master_password_enabled = true;
             settings.security.password_hash = password_hash.map(str::to_string);
             settings.security.derivation_salt = derivation_salt.map(str::to_string);
-            manager.save_settings(&settings).unwrap();
+            std::fs::write(
+                manager.settings_path(),
+                serde_json::to_vec_pretty(&settings).unwrap(),
+            )
+            .unwrap();
 
             let issue = manager.load_settings().unwrap_err();
 
             assert_eq!(issue.kind, StorageIssueKind::InvalidFormat);
             assert_eq!(issue.reason, "Vault settings are incomplete");
         }
+    }
+
+    #[test]
+    fn invalid_derivation_salt_requires_recovery() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let settings = enabled_vault_settings("hash", "not-a-valid-salt");
+        assert!(manager.save_settings(&settings).is_err());
+        std::fs::write(
+            manager.settings_path(),
+            serde_json::to_vec_pretty(&settings).unwrap(),
+        )
+        .unwrap();
+
+        let issue = manager.load_settings().unwrap_err();
+        assert_eq!(issue.kind, StorageIssueKind::InvalidFormat);
+        assert_eq!(issue.reason, "Vault derivation salt is invalid");
     }
 
     #[test]
@@ -999,9 +1384,11 @@ mod tests {
     fn disabled_vault_with_encrypted_data_requires_recovery() {
         let directory = tempfile::tempdir().unwrap();
         let manager = DataManager::from_app_data_dir(directory.path().join("app"));
-        manager
-            .save_data(&[encrypted_snippet("disabled-secret")])
-            .unwrap();
+        std::fs::write(
+            &manager.file_path,
+            serde_json::to_vec(&vec![encrypted_snippet("disabled-secret")]).unwrap(),
+        )
+        .unwrap();
         manager.save_settings(&AppSettings::default()).unwrap();
 
         let status = manager.storage_status();
@@ -1015,14 +1402,11 @@ mod tests {
     fn complete_enabled_vault_metadata_keeps_encrypted_data_healthy() {
         let directory = tempfile::tempdir().unwrap();
         let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let settings = enabled_vault_settings("hash", FIRST_VALID_SALT);
+        manager.save_settings(&settings).unwrap();
         manager
             .save_data(&[encrypted_snippet("healthy-secret")])
             .unwrap();
-        let mut settings = AppSettings::default();
-        settings.security.master_password_enabled = true;
-        settings.security.password_hash = Some("hash".to_string());
-        settings.security.derivation_salt = Some("salt".to_string());
-        manager.save_settings(&settings).unwrap();
 
         let status = manager.storage_status();
 
@@ -1030,6 +1414,154 @@ mod tests {
         assert!(status.settings_issue.is_none());
         assert!(status.has_encrypted_secrets);
         assert!(!manager.has_storage_issues());
+    }
+
+    #[test]
+    fn embedded_vault_metadata_recovers_missing_settings() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let settings = enabled_vault_settings("original-hash", FIRST_VALID_SALT);
+        manager.save_settings(&settings).unwrap();
+        manager
+            .save_data(&[encrypted_snippet("recoverable-secret")])
+            .unwrap();
+
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manager.file_path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], 1);
+        assert_eq!(
+            persisted["vaultMetadata"]["derivationSalt"],
+            FIRST_VALID_SALT
+        );
+
+        std::fs::remove_file(manager.settings_path()).unwrap();
+        let status = manager.storage_status();
+        assert!(status.settings_issue.is_some());
+        assert!(status.vault_metadata_recoverable);
+
+        assert_eq!(manager.recover_vault_metadata().unwrap(), None);
+        let recovered = manager.load_settings().unwrap();
+        assert_eq!(
+            recovered.security.password_hash.as_deref(),
+            Some("original-hash")
+        );
+        assert_eq!(
+            recovered.security.derivation_salt.as_deref(),
+            Some(FIRST_VALID_SALT)
+        );
+        assert!(!manager.has_storage_issues());
+    }
+
+    #[test]
+    fn legacy_encrypted_data_is_upgraded_with_recoverable_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let settings = enabled_vault_settings("legacy-hash", FIRST_VALID_SALT);
+        manager.save_settings(&settings).unwrap();
+        let legacy_data = serde_json::to_vec(&vec![encrypted_snippet("legacy-secret")]).unwrap();
+        std::fs::write(&manager.file_path, &legacy_data).unwrap();
+
+        assert!(manager.ensure_vault_metadata_redundancy().unwrap());
+        assert!(!manager.ensure_vault_metadata_redundancy().unwrap());
+        let migration_copy = std::fs::read_dir(manager.file_path.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .find(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("sklad.pre_metadata_migration_")
+            })
+            .unwrap();
+        assert_eq!(std::fs::read(migration_copy.path()).unwrap(), legacy_data);
+        std::fs::remove_file(manager.settings_path()).unwrap();
+
+        let status = manager.storage_status();
+        assert!(status.vault_metadata_recoverable);
+        manager.recover_vault_metadata().unwrap();
+        assert_eq!(
+            manager
+                .load_settings()
+                .unwrap()
+                .security
+                .derivation_salt
+                .as_deref(),
+            Some(FIRST_VALID_SALT)
+        );
+    }
+
+    #[test]
+    fn encrypted_backup_restores_its_vault_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        let settings = enabled_vault_settings("backup-hash", FIRST_VALID_SALT);
+        manager.save_settings(&settings).unwrap();
+        std::fs::write(
+            &manager.file_path,
+            serde_json::to_vec(&vec![encrypted_snippet("backup-secret")]).unwrap(),
+        )
+        .unwrap();
+        manager.create_backup().unwrap();
+        let backup = manager.list_backups().remove(0);
+        assert!(backup.has_vault_metadata);
+
+        std::fs::remove_file(&manager.file_path).unwrap();
+        std::fs::remove_file(manager.settings_path()).unwrap();
+        let status = manager.storage_status();
+        assert_eq!(
+            status
+                .newest_vault_backup
+                .as_ref()
+                .map(|item| &item.filename),
+            Some(&backup.filename)
+        );
+
+        manager.restore_backup(&backup.filename).unwrap();
+        assert_eq!(manager.load_data().unwrap()[0].label, "backup-secret");
+        assert_eq!(
+            manager
+                .load_settings()
+                .unwrap()
+                .security
+                .derivation_salt
+                .as_deref(),
+            Some(FIRST_VALID_SALT)
+        );
+        assert!(!manager.has_storage_issues());
+    }
+
+    #[test]
+    fn embedded_metadata_detects_and_repairs_mismatched_settings() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = DataManager::from_app_data_dir(directory.path().join("app"));
+        manager
+            .save_settings(&enabled_vault_settings("first-hash", FIRST_VALID_SALT))
+            .unwrap();
+        manager
+            .save_data(&[encrypted_snippet("protected")])
+            .unwrap();
+        manager
+            .save_settings(&enabled_vault_settings("second-hash", SECOND_VALID_SALT))
+            .unwrap();
+
+        let status = manager.storage_status();
+        assert_eq!(
+            status.settings_issue.unwrap().kind,
+            StorageIssueKind::VaultMetadata
+        );
+        assert!(status.vault_metadata_recoverable);
+
+        let recovery_copy = manager.recover_vault_metadata().unwrap().unwrap();
+        assert!(recovery_copy.starts_with("settings.vault_recovery_"));
+        let repaired = manager.load_settings().unwrap();
+        assert_eq!(
+            repaired.security.password_hash.as_deref(),
+            Some("first-hash")
+        );
+        assert_eq!(
+            repaired.security.derivation_salt.as_deref(),
+            Some(FIRST_VALID_SALT)
+        );
     }
 
     #[test]
@@ -1097,9 +1629,11 @@ mod tests {
     fn invalid_settings_with_encrypted_data_cannot_be_reset_without_vault_recovery() {
         let directory = tempfile::tempdir().unwrap();
         let manager = DataManager::from_app_data_dir(directory.path().join("app"));
-        manager
-            .save_data(&[encrypted_snippet("protected")])
-            .unwrap();
+        std::fs::write(
+            &manager.file_path,
+            serde_json::to_vec(&vec![encrypted_snippet("protected")]).unwrap(),
+        )
+        .unwrap();
         let invalid_settings = b"{invalid settings";
         std::fs::write(manager.settings_path(), invalid_settings).unwrap();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,9 +32,10 @@ pub fn run() {
         )
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             let _ = app.emit("single-instance", ());
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.set_focus();
+            if DataManager::new(app).has_storage_issues() {
+                show_storage_recovery(app);
+            } else {
+                show_main_window(app);
             }
         }))
         .plugin(
@@ -43,11 +44,11 @@ pub fn run() {
                     if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
                         let data_manager = DataManager::new(app);
                         if data_manager.has_storage_issues() {
-                            show_main_window(app);
+                            show_storage_recovery(app);
                             return;
                         }
                         let Ok(settings) = data_manager.load_settings() else {
-                            show_main_window(app);
+                            show_storage_recovery(app);
                             return;
                         };
 
@@ -118,6 +119,9 @@ pub fn run() {
             let nodes = if storage_needs_recovery {
                 Vec::new()
             } else {
+                if let Err(error) = data_manager.ensure_vault_metadata_redundancy() {
+                    log::error!("Failed to add recoverable vault metadata: {}", error);
+                }
                 data_manager.load_data().unwrap_or_default()
             };
             let menu_nodes = if storage_needs_recovery {
@@ -188,7 +192,13 @@ pub fn run() {
                             log::info!("Quit menu item selected. Exiting app.");
                             app.exit(0);
                         }
-                        "open" => show_main_window(app),
+                        "open" => {
+                            if DataManager::new(app).has_storage_issues() {
+                                show_storage_recovery(app);
+                            } else {
+                                show_main_window(app);
+                            }
+                        }
                         snippet_id => handle_snippet_click(app, snippet_id.to_string()),
                     }
                 })
@@ -203,11 +213,11 @@ pub fn run() {
 
                         let data_manager = DataManager::new(app);
                         if data_manager.has_storage_issues() {
-                            show_main_window(app);
+                            show_storage_recovery(app);
                             return;
                         }
                         let Ok(settings) = data_manager.load_settings() else {
-                            show_main_window(app);
+                            show_storage_recovery(app);
                             return;
                         };
                         log::info!(
@@ -304,6 +314,7 @@ pub fn run() {
             commands::get_storage_status,
             commands::reset_corrupt_data,
             commands::reset_corrupt_settings,
+            commands::recover_vault_metadata,
             commands::discard_unrecoverable_vault_data,
             commands::open_data_directory
         ])
@@ -389,9 +400,14 @@ fn show_main_window(app: &tauri::AppHandle) {
     }
 }
 
+fn show_storage_recovery(app: &tauri::AppHandle) {
+    let _ = app.emit("storage-recovery-required", ());
+    show_main_window(app);
+}
+
 fn handle_snippet_click(app: &tauri::AppHandle, id: String) {
     if DataManager::new(app).has_storage_issues() {
-        show_main_window(app);
+        show_storage_recovery(app);
         return;
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,7 +42,14 @@ pub fn run() {
                 .with_handler(|app, shortcut, event| {
                     if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
                         let data_manager = DataManager::new(app);
-                        let settings = data_manager.load_settings();
+                        if data_manager.has_storage_issues() {
+                            show_main_window(app);
+                            return;
+                        }
+                        let Ok(settings) = data_manager.load_settings() else {
+                            show_main_window(app);
+                            return;
+                        };
 
                         // Parse the shortcuts from settings to compare IDs
                         let search_shortcut = settings
@@ -91,13 +98,32 @@ pub fn run() {
             let data_manager = DataManager::new(handle);
 
             // Read settings, configure logging flag
-            let settings = data_manager.load_settings();
+            let settings_result = data_manager.load_settings();
+            let nodes_result = data_manager.load_data();
+            let storage_needs_recovery = settings_result.is_err() || nodes_result.is_err();
+
+            if let Err(issue) = &settings_result {
+                log::error!("Storage recovery required for {}", issue.file_name);
+            }
+            if let Err(issue) = &nodes_result {
+                log::error!("Storage recovery required for {}", issue.file_name);
+            }
+
+            let settings = settings_result.unwrap_or_else(|_| crate::models::AppSettings {
+                auto_backup_enabled: false,
+                ..Default::default()
+            });
             LOGGING_ENABLED.store(settings.logging_enabled, Ordering::Relaxed);
 
-            let nodes = data_manager.load_data();
-            let menu = TrayGenerator::generate_menu(handle, &nodes)?;
+            let nodes = nodes_result.unwrap_or_default();
+            let menu_nodes = if storage_needs_recovery {
+                &[][..]
+            } else {
+                nodes.as_slice()
+            };
+            let menu = TrayGenerator::generate_menu(handle, menu_nodes, &settings)?;
 
-            if settings.auto_backup_enabled {
+            if !storage_needs_recovery && settings.auto_backup_enabled {
                 if let Err(e) = data_manager.create_backup() {
                     log::error!("Failed to create startup backup: {}", e);
                 } else if let Err(e) = data_manager.rotate_backups(settings.auto_backup_count) {
@@ -172,7 +198,14 @@ pub fn run() {
                         let app = tray.app_handle();
 
                         let data_manager = DataManager::new(app);
-                        let settings = data_manager.load_settings();
+                        if data_manager.has_storage_issues() {
+                            show_main_window(app);
+                            return;
+                        }
+                        let Ok(settings) = data_manager.load_settings() else {
+                            show_main_window(app);
+                            return;
+                        };
                         log::info!(
                             "Tray left-clicked. Action configured: {}",
                             settings.tray_click_action
@@ -199,7 +232,7 @@ pub fn run() {
             let args: Vec<String> = env::args().collect();
             let start_minimized = args.contains(&"--minimized".to_string());
 
-            if !start_minimized {
+            if !start_minimized || storage_needs_recovery {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.set_focus();
@@ -207,11 +240,9 @@ pub fn run() {
             }
 
             // Register global shortcuts
-            let settings = data_manager.load_settings();
-
             use tauri_plugin_global_shortcut::GlobalShortcutExt;
             let shortcut_str = &settings.global_search_shortcut;
-            if !shortcut_str.is_empty() {
+            if !storage_needs_recovery && !shortcut_str.is_empty() {
                 match shortcut_str.parse::<tauri_plugin_global_shortcut::Shortcut>() {
                     Ok(shortcut) => {
                         if let Err(e) = app.global_shortcut().register(shortcut) {
@@ -229,7 +260,7 @@ pub fn run() {
             }
 
             let create_shortcut_str = &settings.global_create_shortcut;
-            if !create_shortcut_str.is_empty() {
+            if !storage_needs_recovery && !create_shortcut_str.is_empty() {
                 match create_shortcut_str.parse::<tauri_plugin_global_shortcut::Shortcut>() {
                     Ok(shortcut) => {
                         if let Err(e) = app.global_shortcut().register(shortcut) {
@@ -265,7 +296,11 @@ pub fn run() {
             commands::is_vault_unlocked,
             commands::create_backup,
             commands::get_backups,
-            commands::restore_backup
+            commands::restore_backup,
+            commands::get_storage_status,
+            commands::reset_corrupt_data,
+            commands::reset_corrupt_settings,
+            commands::open_data_directory
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -286,14 +321,15 @@ pub fn run() {
                     }
                 } else {
                     let data_manager = DataManager::new(app_handle);
-                    let settings = data_manager.load_settings();
-                    if settings.auto_backup_enabled {
-                        if let Err(e) = data_manager.create_backup() {
-                            log::error!("Failed to create backup on exit: {}", e);
-                        } else if let Err(e) =
-                            data_manager.rotate_backups(settings.auto_backup_count)
-                        {
-                            log::error!("Failed to rotate backups on exit: {}", e);
+                    if let Ok(settings) = data_manager.load_settings() {
+                        if settings.auto_backup_enabled {
+                            if let Err(e) = data_manager.create_backup() {
+                                log::error!("Failed to create backup on exit: {}", e);
+                            } else if let Err(e) =
+                                data_manager.rotate_backups(settings.auto_backup_count)
+                            {
+                                log::error!("Failed to rotate backups on exit: {}", e);
+                            }
                         }
                     }
                 }
@@ -322,12 +358,13 @@ pub fn run() {
         #[cfg(not(target_os = "macos"))]
         if let tauri::RunEvent::ExitRequested { .. } = _event {
             let data_manager = DataManager::new(_app_handle);
-            let settings = data_manager.load_settings();
-            if settings.auto_backup_enabled {
-                if let Err(e) = data_manager.create_backup() {
-                    log::error!("Failed to create backup on exit: {}", e);
-                } else if let Err(e) = data_manager.rotate_backups(settings.auto_backup_count) {
-                    log::error!("Failed to rotate backups on exit: {}", e);
+            if let Ok(settings) = data_manager.load_settings() {
+                if settings.auto_backup_enabled {
+                    if let Err(e) = data_manager.create_backup() {
+                        log::error!("Failed to create backup on exit: {}", e);
+                    } else if let Err(e) = data_manager.rotate_backups(settings.auto_backup_count) {
+                        log::error!("Failed to rotate backups on exit: {}", e);
+                    }
                 }
             }
         }
@@ -342,6 +379,11 @@ fn show_main_window(app: &tauri::AppHandle) {
 }
 
 fn handle_snippet_click(app: &tauri::AppHandle, id: String) {
+    if DataManager::new(app).has_storage_issues() {
+        show_main_window(app);
+        return;
+    }
+
     let vault_manager = app.state::<crate::security::VaultManager>();
 
     if let Err(e) = crate::commands::copy_snippet(app.clone(), vault_manager, id.clone()) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,7 +41,7 @@ pub fn run() {
             tauri_plugin_global_shortcut::Builder::new()
                 .with_handler(|app, shortcut, event| {
                     if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                        let data_manager = DataManager::new(&app);
+                        let data_manager = DataManager::new(app);
                         let settings = data_manager.load_settings();
 
                         // Parse the shortcuts from settings to compare IDs
@@ -285,7 +285,7 @@ pub fn run() {
                         let _ = window.hide();
                     }
                 } else {
-                    let data_manager = DataManager::new(&app_handle);
+                    let data_manager = DataManager::new(app_handle);
                     let settings = data_manager.load_settings();
                     if settings.auto_backup_enabled {
                         if let Err(e) = data_manager.create_backup() {
@@ -320,19 +320,16 @@ pub fn run() {
         }
 
         #[cfg(not(target_os = "macos"))]
-        match _event {
-            tauri::RunEvent::ExitRequested { .. } => {
-                let data_manager = DataManager::new(&_app_handle);
-                let settings = data_manager.load_settings();
-                if settings.auto_backup_enabled {
-                    if let Err(e) = data_manager.create_backup() {
-                        log::error!("Failed to create backup on exit: {}", e);
-                    } else if let Err(e) = data_manager.rotate_backups(settings.auto_backup_count) {
-                        log::error!("Failed to rotate backups on exit: {}", e);
-                    }
+        if let tauri::RunEvent::ExitRequested { .. } = _event {
+            let data_manager = DataManager::new(_app_handle);
+            let settings = data_manager.load_settings();
+            if settings.auto_backup_enabled {
+                if let Err(e) = data_manager.create_backup() {
+                    log::error!("Failed to create backup on exit: {}", e);
+                } else if let Err(e) = data_manager.rotate_backups(settings.auto_backup_count) {
+                    log::error!("Failed to rotate backups on exit: {}", e);
                 }
             }
-            _ => {}
         }
     });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,25 +97,29 @@ pub fn run() {
             let handle = app.handle();
             let data_manager = DataManager::new(handle);
 
-            // Read settings, configure logging flag
-            let settings_result = data_manager.load_settings();
-            let nodes_result = data_manager.load_data();
-            let storage_needs_recovery = settings_result.is_err() || nodes_result.is_err();
+            // Check both files together before any first-run initialization can write to disk.
+            let storage_status = data_manager.storage_status();
+            let storage_needs_recovery =
+                storage_status.data_issue.is_some() || storage_status.settings_issue.is_some();
 
-            if let Err(issue) = &settings_result {
+            if let Some(issue) = &storage_status.settings_issue {
                 log::error!("Storage recovery required for {}", issue.file_name);
             }
-            if let Err(issue) = &nodes_result {
+            if let Some(issue) = &storage_status.data_issue {
                 log::error!("Storage recovery required for {}", issue.file_name);
             }
 
-            let settings = settings_result.unwrap_or_else(|_| crate::models::AppSettings {
-                auto_backup_enabled: false,
-                ..Default::default()
-            });
+            let mut settings = data_manager.load_settings().unwrap_or_default();
+            if storage_needs_recovery {
+                settings.auto_backup_enabled = false;
+            }
             LOGGING_ENABLED.store(settings.logging_enabled, Ordering::Relaxed);
 
-            let nodes = nodes_result.unwrap_or_default();
+            let nodes = if storage_needs_recovery {
+                Vec::new()
+            } else {
+                data_manager.load_data().unwrap_or_default()
+            };
             let menu_nodes = if storage_needs_recovery {
                 &[][..]
             } else {
@@ -300,6 +304,7 @@ pub fn run() {
             commands::get_storage_status,
             commands::reset_corrupt_data,
             commands::reset_corrupt_settings,
+            commands::discard_unrecoverable_vault_data,
             commands::open_data_directory
         ])
         .build(tauri::generate_context!())
@@ -321,7 +326,10 @@ pub fn run() {
                     }
                 } else {
                     let data_manager = DataManager::new(app_handle);
-                    if let Ok(settings) = data_manager.load_settings() {
+                    if !data_manager.has_storage_issues() {
+                        let Ok(settings) = data_manager.load_settings() else {
+                            return;
+                        };
                         if settings.auto_backup_enabled {
                             if let Err(e) = data_manager.create_backup() {
                                 log::error!("Failed to create backup on exit: {}", e);
@@ -358,7 +366,10 @@ pub fn run() {
         #[cfg(not(target_os = "macos"))]
         if let tauri::RunEvent::ExitRequested { .. } = _event {
             let data_manager = DataManager::new(_app_handle);
-            if let Ok(settings) = data_manager.load_settings() {
+            if !data_manager.has_storage_issues() {
+                let Ok(settings) = data_manager.load_settings() else {
+                    return;
+                };
                 if settings.auto_backup_enabled {
                     if let Err(e) = data_manager.create_backup() {
                         log::error!("Failed to create backup on exit: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -145,7 +145,7 @@ pub fn run() {
                     about_metadata.website = Some("https://github.com/Rench321/sklad".to_string());
                     about_metadata.website_label = Some("GitHub Repository".to_string());
                     about_metadata.comments =
-                        Some("Industrial-grade secure snippet warehouse".to_string());
+                        Some("Local-only, tray-first snippet manager".to_string());
 
                     if let Ok(about_item) =
                         PredefinedMenuItem::about(app.handle(), None, Some(about_metadata))

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -42,8 +42,6 @@ pub struct Node {
 pub struct AppSettingsSecurity {
     #[serde(rename = "lockTimeout")]
     pub lock_timeout: u32,
-    #[serde(rename = "clearClipboard")]
-    pub clear_clipboard: bool,
     #[serde(rename = "masterPasswordEnabled")]
     pub master_password_enabled: bool,
     #[serde(rename = "passwordHash")]
@@ -55,9 +53,8 @@ pub struct AppSettingsSecurity {
 impl Default for AppSettingsSecurity {
     fn default() -> Self {
         Self {
-            lock_timeout: 300000, // 5 minutes default
-            clear_clipboard: false,
-            master_password_enabled: false, // No password set yet on fresh install
+            lock_timeout: 300000,
+            master_password_enabled: false,
             password_hash: None,
             derivation_salt: None,
         }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -5,6 +5,8 @@ pub struct BackupInfo {
     pub filename: String,
     pub timestamp: i64,
     pub size: u64,
+    #[serde(rename = "hasVaultMetadata")]
+    pub has_vault_metadata: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -98,3 +98,64 @@ pub fn decrypt(ciphertext_hex: &str, nonce_hex: &str, key: &Key) -> Result<Strin
 
     String::from_utf8(plaintext).map_err(|_| "Invalid UTF-8".to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{decrypt, derive_key_from_password, encrypt, hash_password, verify_password};
+
+    const FIRST_SALT: &str = "0123456789abcdef";
+    const SECOND_SALT: &str = "fedcba9876543210";
+
+    #[test]
+    fn password_hash_accepts_only_the_original_password() {
+        let hash = hash_password("correct horse battery staple");
+
+        assert!(verify_password("correct horse battery staple", &hash));
+        assert!(!verify_password("wrong password", &hash));
+        assert!(!verify_password(
+            "correct horse battery staple",
+            "not-a-valid-hash"
+        ));
+    }
+
+    #[test]
+    fn key_derivation_is_stable_for_the_same_password_and_salt() {
+        let first = derive_key_from_password("master password", FIRST_SALT);
+        let repeated = derive_key_from_password("master password", FIRST_SALT);
+        let different_salt = derive_key_from_password("master password", SECOND_SALT);
+
+        assert_eq!(first, repeated);
+        assert_ne!(first, different_salt);
+    }
+
+    #[test]
+    fn encryption_round_trip_preserves_unicode_and_rejects_the_wrong_key() {
+        let key = derive_key_from_password("master password", FIRST_SALT);
+        let wrong_key = derive_key_from_password("wrong password", FIRST_SALT);
+        let plaintext = "секрет 🔐\nsecond line";
+
+        let (ciphertext, nonce) = encrypt(plaintext, &key).unwrap();
+
+        assert_eq!(nonce.len(), 24);
+        assert_ne!(ciphertext, hex::encode(plaintext));
+        assert_eq!(decrypt(&ciphertext, &nonce, &key).unwrap(), plaintext);
+        assert_eq!(
+            decrypt(&ciphertext, &nonce, &wrong_key),
+            Err("Decryption failed".to_string())
+        );
+    }
+
+    #[test]
+    fn decryption_rejects_invalid_hex_without_exposing_input() {
+        let key = derive_key_from_password("master password", FIRST_SALT);
+
+        assert_eq!(
+            decrypt("sensitive-invalid-value", "00", &key),
+            Err("Invalid ciphertext hex".to_string())
+        );
+        assert_eq!(
+            decrypt("00", "sensitive-invalid-nonce", &key),
+            Err("Invalid nonce hex".to_string())
+        );
+    }
+}

--- a/src-tauri/src/tray_generator.rs
+++ b/src-tauri/src/tray_generator.rs
@@ -1,23 +1,22 @@
-use crate::models::{Node, NodeType};
+use crate::models::{AppSettings, Node, NodeType};
 use tauri::{
     menu::{Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
     AppHandle, Runtime,
 };
 
-use crate::data_manager::DataManager;
-
 pub struct TrayGenerator;
 
 impl TrayGenerator {
-    pub fn generate_menu<R: Runtime>(app: &AppHandle<R>, nodes: &[Node]) -> tauri::Result<Menu<R>> {
+    pub fn generate_menu<R: Runtime>(
+        app: &AppHandle<R>,
+        nodes: &[Node],
+        settings: &AppSettings,
+    ) -> tauri::Result<Menu<R>> {
         log::info!(
             "Generating tray menu. Received {} top-level nodes.",
             nodes.len()
         );
         let mut menu_builder = MenuBuilder::new(app);
-
-        let data_manager = DataManager::new(app);
-        let settings = data_manager.load_settings();
 
         let is_top = settings.tray_menu_root_position == "top";
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Sklad",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "sklad",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -47,6 +47,10 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "category": "Productivity",
+    "shortDescription": "Local-only, tray-first snippet manager",
+    "longDescription": "Store, organize, search, and securely access reusable text from the system tray without sending application data over the network.",
+    "copyright": "Copyright © 2026 Pavel",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,17 @@ function App() {
   const [showUnsavedModal, setShowUnsavedModal] = useState(false);
   const [pendingClose, setPendingClose] = useState(false);
 
+  const enterStorageRecovery = (status: StorageStatus) => {
+    setStorageStatus(status);
+    setNodes([]);
+    setSelectedNode(null);
+    setSettings(null);
+    setIsUnlocked(false);
+    setShowLockModal(false);
+    setShowSetupModal(false);
+    setLoaded(true);
+  };
+
   useEffect(() => {
     initializeApp();
 
@@ -68,10 +79,36 @@ function App() {
       loadNodes();
     });
 
+    const unlistenRestore = listen("storage-restored", () => {
+      void initializeApp();
+    });
+
+    const inspectStorage = async () => {
+      try {
+        const status = await api.getStorageStatus();
+        if (status.dataIssue || status.settingsIssue) {
+          enterStorageRecovery(status);
+        }
+      } catch (error) {
+        console.error("Failed to inspect storage", error);
+      }
+    };
+
+    const unlistenRecovery = listen("storage-recovery-required", () => {
+      void inspectStorage();
+    });
+
+    const unlistenFocus = getCurrentWebviewWindow().onFocusChanged(({ payload: focused }) => {
+      if (focused) void inspectStorage();
+    });
+
     return () => {
       unlistenUnlock.then((fn) => fn());
       unlistenOpenSnippet.then((fn) => fn());
       unlistenUpdate.then((fn) => fn());
+      unlistenRestore.then((fn) => fn());
+      unlistenRecovery.then((fn) => fn());
+      unlistenFocus.then((fn) => fn());
     };
   }, []);
 
@@ -88,12 +125,7 @@ function App() {
     try {
       const status = await api.getStorageStatus();
       if (status.dataIssue || status.settingsIssue) {
-        setStorageStatus(status);
-        setNodes([]);
-        setSelectedNode(null);
-        setSettings(null);
-        setIsUnlocked(false);
-        setLoaded(true);
+        enterStorageRecovery(status);
         return;
       }
 
@@ -115,8 +147,7 @@ function App() {
       try {
         const status = await api.getStorageStatus();
         if (status.dataIssue || status.settingsIssue) {
-          setStorageStatus(status);
-          setSettings(null);
+          enterStorageRecovery(status);
         }
       } catch (statusError) {
         console.error("Failed to inspect storage", statusError);
@@ -147,10 +178,7 @@ function App() {
       try {
         const status = await api.getStorageStatus();
         if (status.dataIssue || status.settingsIssue) {
-          setStorageStatus(status);
-          setSettings(null);
-          setNodes([]);
-          setSelectedNode(null);
+          enterStorageRecovery(status);
         }
       } catch (statusError) {
         console.error("Failed to inspect storage", statusError);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { useRef } from "react";
 import { Settings } from "@/components/Settings";
 import { UnsavedChangesModal } from "@/components/UnsavedChangesModal";
+import { StorageRecovery } from "@/components/StorageRecovery";
 import { api } from "@/lib/api";
 import {
   findNodeById,
@@ -19,7 +20,7 @@ import {
   insertNodeAtPosition,
   isDescendantOf,
 } from "@/lib/treeUtils";
-import { Node, AppSettings } from "@/types";
+import { Node, AppSettings, StorageStatus } from "@/types";
 import { Container, Search, Lock, Unlock, Settings as SettingsIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +34,7 @@ function App() {
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [storageStatus, setStorageStatus] = useState<StorageStatus | null>(null);
   const [pendingCopyAction, setPendingCopyAction] = useState<{
     id: string;
     autoHide: boolean;
@@ -84,6 +86,17 @@ function App() {
 
   const initializeApp = async () => {
     try {
+      const status = await api.getStorageStatus();
+      if (status.dataIssue || status.settingsIssue) {
+        setStorageStatus(status);
+        setNodes([]);
+        setSelectedNode(null);
+        setSettings(null);
+        setIsUnlocked(false);
+        setLoaded(true);
+        return;
+      }
+
       const [data, appSettings, unlocked] = await Promise.all([
         api.getData(),
         api.getSettings(),
@@ -93,11 +106,21 @@ function App() {
       const freshNodes = data ?? [];
       setNodes(freshNodes);
       setSettings(appSettings);
+      setStorageStatus(null);
       setIsUnlocked(unlocked);
       refreshSelectedNode(freshNodes);
       setLoaded(true);
     } catch (e) {
       console.error(e);
+      try {
+        const status = await api.getStorageStatus();
+        if (status.dataIssue || status.settingsIssue) {
+          setStorageStatus(status);
+          setSettings(null);
+        }
+      } catch (statusError) {
+        console.error("Failed to inspect storage", statusError);
+      }
       setLoaded(true);
     }
   };
@@ -121,6 +144,17 @@ function App() {
       refreshSelectedNode(freshNodes);
     } catch (e) {
       console.error(e);
+      try {
+        const status = await api.getStorageStatus();
+        if (status.dataIssue || status.settingsIssue) {
+          setStorageStatus(status);
+          setSettings(null);
+          setNodes([]);
+          setSelectedNode(null);
+        }
+      } catch (statusError) {
+        console.error("Failed to inspect storage", statusError);
+      }
     }
   };
 
@@ -336,6 +370,11 @@ function App() {
       unlistenPromise.then(unlisten => unlisten());
     };
   }, [selectedNode, settings]);
+
+  if (loaded && storageStatus && (storageStatus.dataIssue || storageStatus.settingsIssue)) {
+    return <StorageRecovery status={storageStatus} onRetry={initializeApp} />;
+  }
+
   if (!loaded || !settings) {
     return (
       <div className="flex items-center justify-center h-screen bg-background">

--- a/src/CreateWindow.tsx
+++ b/src/CreateWindow.tsx
@@ -3,6 +3,7 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
 import { Node } from "@/types";
+import { routeToStorageRecovery } from "@/lib/storageRecovery";
 
 export function CreateWindow() {
     const [name, setName] = React.useState("");
@@ -34,10 +35,11 @@ export function CreateWindow() {
             });
         });
 
-        const unlistenFocus = window.onFocusChanged(({ payload: focused }) => {
+        const unlistenFocus = window.onFocusChanged(async ({ payload: focused }) => {
             if (!focused) {
                 window.hide();
             } else {
+                if (await routeToStorageRecovery()) return;
                 setName("");
                 setValue("");
                 setTimeout(() => {
@@ -98,6 +100,7 @@ export function CreateWindow() {
             setValue("");
         } catch (e) {
             console.error("Failed to save snippet", e);
+            await routeToStorageRecovery();
         } finally {
             setIsSaving(false);
         }

--- a/src/SearchWindow.tsx
+++ b/src/SearchWindow.tsx
@@ -140,18 +140,15 @@ export function SearchWindow() {
 
     return (
         <div className="flex flex-col h-screen w-screen bg-popover text-popover-foreground rounded-xl overflow-hidden shadow-2xl border border-border">
-            <Command className="flex-1 bg-transparent">
-                <div className="flex items-center px-4 border-b border-border/50">
-                    <Search className="w-5 h-5 text-muted-foreground mr-3" />
-                    <CommandInput
-                        ref={inputRef}
-                        value={searchValue}
-                        onValueChange={setSearchValue}
-                        placeholder="Search snippets..."
-                        className="h-14 border-0 focus:ring-0 text-lg flex-1 bg-transparent outline-none"
-                        autoFocus
-                    />
-                </div>
+            <Command className="flex-1 bg-transparent [&_[cmdk-input-wrapper]]:border-border/50 [&_[cmdk-input-wrapper]]:px-4 [&_[cmdk-input-wrapper]_svg]:mr-3 [&_[cmdk-input-wrapper]_svg]:size-5">
+                <CommandInput
+                    ref={inputRef}
+                    value={searchValue}
+                    onValueChange={setSearchValue}
+                    placeholder="Search snippets..."
+                    className="h-14 border-0 focus:ring-0 text-lg flex-1 bg-transparent outline-none"
+                    autoFocus
+                />
                 <CommandList className="flex-1 overflow-y-auto max-h-[340px] p-2">
                     <CommandEmpty className="py-12 text-center text-muted-foreground">
                         <div className="flex flex-col items-center justify-center gap-3">

--- a/src/SearchWindow.tsx
+++ b/src/SearchWindow.tsx
@@ -12,6 +12,7 @@ import { Node } from "@/types";
 import { FileText, Lock, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
+import { routeToStorageRecovery } from "@/lib/storageRecovery";
 
 export function SearchWindow() {
     const [nodes, setNodes] = React.useState<Node[]>([]);
@@ -20,16 +21,20 @@ export function SearchWindow() {
     const inputRef = React.useRef<HTMLInputElement>(null);
 
     React.useEffect(() => {
-        const loadNodes = async () => {
-            const data = await api.getData();
-            setNodes(data || []);
+        const loadWindowData = async () => {
+            try {
+                if (await routeToStorageRecovery()) return;
+                const [data, settings] = await Promise.all([
+                    api.getData(),
+                    api.getSettings(),
+                ]);
+                setNodes(data || []);
+                setGlobalSearchAction(settings.globalSearchAction || 'copy');
+            } catch (error) {
+                console.error("Failed to load global search", error);
+            }
         };
-        const loadSettings = async () => {
-            const settings = await api.getSettings();
-            setGlobalSearchAction(settings.globalSearchAction || 'copy');
-        };
-        loadNodes();
-        loadSettings();
+        void loadWindowData();
     }, []);
 
     React.useEffect(() => {
@@ -60,6 +65,7 @@ export function SearchWindow() {
             if (!focused) {
                 window.hide();
             } else {
+                if (await routeToStorageRecovery()) return;
                 setSearchValue("");
                 const [data, settings] = await Promise.all([
                     api.getData(),
@@ -119,6 +125,7 @@ export function SearchWindow() {
             }
         } catch (e: any) {
             console.error("Failed to process snippet", e);
+            if (await routeToStorageRecovery()) return;
             if (e === "Vault is Locked") {
                 const mainWindow = await (await import("@tauri-apps/api/webviewWindow")).WebviewWindow.getByLabel("main");
                 if (mainWindow) {

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -49,13 +49,10 @@ export function CommandPalette({ nodes, onSelect }: CommandPaletteProps) {
 
     return (
         <CommandDialog open={open} onOpenChange={setOpen}>
-            <div className="flex items-center border-b border-border/50 px-3">
-                <Search className="w-4 h-4 text-muted-foreground mr-2" />
-                <CommandInput
-                    placeholder="Search snippets and folders..."
-                    className="border-0 focus:ring-0"
-                />
-            </div>
+            <CommandInput
+                placeholder="Search snippets and folders..."
+                className="border-0 focus:ring-0"
+            />
             <CommandList className="max-h-[400px]">
                 <CommandEmpty className="py-8 text-center">
                     <div className="flex flex-col items-center gap-2 text-muted-foreground">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -227,7 +227,7 @@ export function Settings({ settings, onResetTrigger, onSetupTrigger, onSettingsU
                             {snippetsPath || "Loading path..."}
                         </div>
                         <p className="text-[10px] text-muted-foreground/60 italic">
-                            All your snippets, folders, and settings are stored in this JSON file.
+                            Snippets and folders are stored here. Encrypted libraries also include the vault metadata needed for password-based recovery; other preferences remain in settings.json.
                         </p>
                     </div>
 
@@ -326,7 +326,7 @@ export function Settings({ settings, onResetTrigger, onSetupTrigger, onSettingsU
                                         Backup History <span className="text-muted-foreground tabular-nums">({backups.length})</span>
                                     </div>
                                     <p className="mt-0.5 text-[10px] text-pretty text-muted-foreground/60">
-                                        Restore points are stored only on this device.
+                                        Restore points stay on this device. New backups containing encrypted snippets include the vault metadata required by the existing master password.
                                     </p>
                                 </div>
                                 <Button
@@ -352,9 +352,17 @@ export function Settings({ settings, onResetTrigger, onSetupTrigger, onSettingsU
                                                 key={backup.filename}
                                                 className="flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border/40 bg-background/50 py-1 pl-3 pr-1 text-xs"
                                             >
-                                                <span className="min-w-0 truncate font-mono tabular-nums text-muted-foreground">
-                                                    {new Date(backup.timestamp).toLocaleString()}
-                                                </span>
+                                                <div className="flex min-w-0 items-center gap-2">
+                                                    {backup.hasVaultMetadata && (
+                                                        <Shield
+                                                            aria-label="Includes vault recovery metadata"
+                                                            className="size-3.5 shrink-0 text-primary/70"
+                                                        />
+                                                    )}
+                                                    <span className="min-w-0 truncate font-mono tabular-nums text-muted-foreground">
+                                                        {new Date(backup.timestamp).toLocaleString()}
+                                                    </span>
+                                                </div>
                                                 <div className="flex shrink-0 items-center gap-1">
                                                     <span className="w-14 text-right tabular-nums text-muted-foreground/60">
                                                         {(backup.size / 1024).toFixed(1)} KB

--- a/src/components/StorageRecovery.tsx
+++ b/src/components/StorageRecovery.tsx
@@ -1,0 +1,302 @@
+import { useState } from "react";
+import {
+  ArchiveRestore,
+  FileWarning,
+  FolderOpen,
+  LoaderCircle,
+  RefreshCw,
+  RotateCcw,
+  ShieldAlert,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import { StorageIssue, StorageStatus } from "@/types";
+import { Button } from "@/components/ui/button";
+
+interface StorageRecoveryProps {
+  status: StorageStatus;
+  onRetry: () => Promise<void>;
+}
+
+type RecoveryAction = "restore" | "reset-data" | "reset-settings" | "retry" | "open";
+type Confirmation = "data" | "settings" | null;
+
+const actionClassName =
+  "min-h-10 active:scale-[0.96] transition-[color,background-color,border-color,box-shadow,transform]";
+
+function readableError(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  return "Recovery could not be completed. The original file was not replaced.";
+}
+
+function IssueCard({ issue }: { issue: StorageIssue }) {
+  const isInvalid = issue.kind === "invalid_format";
+
+  return (
+    <section className="rounded-xl bg-muted/45 p-4 shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.08)]">
+      <div className="flex items-start gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+          <FileWarning aria-hidden="true" className="size-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <h2 className="font-mono text-sm font-semibold">{issue.fileName}</h2>
+            <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+              {isInvalid ? "Invalid format" : "Unreadable"}
+            </span>
+          </div>
+          <p className="mt-2 text-pretty text-sm leading-6 text-muted-foreground">
+            {isInvalid
+              ? "The JSON or its expected structure is invalid. Sklad will not load or overwrite this file until you choose a recovery action."
+              : "Sklad cannot safely read this file. Check its permissions or disk availability, then retry."}
+          </p>
+          <code className="mt-3 block overflow-x-auto rounded-lg bg-background/75 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground shadow-[inset_0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]">
+            {issue.reason}
+          </code>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
+  const [busyAction, setBusyAction] = useState<RecoveryAction | null>(null);
+  const [confirmation, setConfirmation] = useState<Confirmation>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const isBusy = busyAction !== null;
+
+  const runAction = async (
+    action: RecoveryAction,
+    operation: () => Promise<void>,
+  ) => {
+    setBusyAction(action);
+    setError(null);
+    setNotice(null);
+    try {
+      await operation();
+    } catch (operationError) {
+      setError(readableError(operationError));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const restoreBackup = () => {
+    const backup = status.newestValidBackup;
+    if (!backup) return;
+
+    void runAction("restore", async () => {
+      await api.restoreBackup(backup.filename);
+      setNotice("The newest valid backup was restored.");
+      await onRetry();
+    });
+  };
+
+  const resetData = () => {
+    void runAction("reset-data", async () => {
+      const quarantine = await api.resetCorruptData();
+      setConfirmation(null);
+      setNotice(`The original data was preserved as ${quarantine}.`);
+      await onRetry();
+    });
+  };
+
+  const resetSettings = () => {
+    void runAction("reset-settings", async () => {
+      const quarantine = await api.resetCorruptSettings();
+      setConfirmation(null);
+      setNotice(`The original settings were preserved as ${quarantine}.`);
+      await onRetry();
+    });
+  };
+
+  const retry = () => {
+    void runAction("retry", onRetry);
+  };
+
+  const openDirectory = () => {
+    void runAction("open", () => api.openDataDirectory());
+  };
+
+  return (
+    <main className="flex min-h-screen w-screen items-center justify-center overflow-auto bg-industrial p-6 text-foreground">
+      <div className="w-full max-w-2xl rounded-2xl bg-card p-6 shadow-xl ring-1 ring-black/5 dark:ring-white/10">
+        <header className="flex items-start gap-4">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-primary/12 text-primary shadow-[0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.08)]">
+            <ShieldAlert aria-hidden="true" className="size-6" />
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+              Recovery mode
+            </p>
+            <h1 className="mt-1 text-balance text-2xl font-semibold tracking-tight">
+              Storage needs attention
+            </h1>
+            <p className="mt-2 max-w-xl text-pretty text-sm leading-6 text-muted-foreground">
+              Your files have not been replaced. Normal editing and automatic backups are paused until storage is healthy again.
+            </p>
+          </div>
+        </header>
+
+        <div className="mt-6 space-y-3">
+          {status.dataIssue && <IssueCard issue={status.dataIssue} />}
+          {status.settingsIssue && <IssueCard issue={status.settingsIssue} />}
+        </div>
+
+        {status.dataIssue?.kind === "invalid_format" && (
+          <section className="mt-5 rounded-xl bg-primary/6 p-4 shadow-[0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07)]">
+            <h2 className="text-sm font-semibold">Snippet recovery</h2>
+            {status.newestValidBackup ? (
+              <>
+                <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+                  A valid backup is available: <span className="font-mono text-foreground">{status.newestValidBackup.filename}</span>.
+                </p>
+                <Button
+                  className={`mt-3 ${actionClassName}`}
+                  disabled={isBusy}
+                  onClick={restoreBackup}
+                  size="lg"
+                >
+                  {busyAction === "restore" ? (
+                    <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+                  ) : (
+                    <ArchiveRestore aria-hidden="true" />
+                  )}
+                  Restore newest valid backup
+                </Button>
+              </>
+            ) : (
+              <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+                No valid snippet backup was found. You can inspect the file manually or create a fresh library after preserving it in quarantine.
+              </p>
+            )}
+
+            {confirmation === "data" ? (
+              <div className="mt-4 rounded-lg bg-destructive/8 p-3 shadow-[0_0_0_1px_rgba(220,38,38,0.18)]">
+                <p className="text-pretty text-sm font-medium">
+                  Create a fresh library? The damaged file will first be copied to quarantine.
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    className={actionClassName}
+                    disabled={isBusy}
+                    onClick={() => setConfirmation(null)}
+                    variant="outline"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    className={actionClassName}
+                    disabled={isBusy}
+                    onClick={resetData}
+                    variant="destructive"
+                  >
+                    {busyAction === "reset-data" && (
+                      <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+                    )}
+                    Quarantine and reset data
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                className={`mt-3 ${actionClassName}`}
+                disabled={isBusy}
+                onClick={() => setConfirmation("data")}
+                variant="outline"
+              >
+                <RotateCcw aria-hidden="true" />
+                Create fresh library
+              </Button>
+            )}
+          </section>
+        )}
+
+        {status.settingsIssue?.kind === "invalid_format" && (
+          <section className="mt-5 rounded-xl bg-muted/35 p-4 shadow-[0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07)]">
+            <h2 className="text-sm font-semibold">Settings recovery</h2>
+            <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+              Sklad does not currently back up settings. Resetting restores defaults only after preserving the damaged file.
+            </p>
+            {status.hasEncryptedSecrets && (
+              <p className="mt-3 text-pretty rounded-lg bg-destructive/8 px-3 py-2 text-sm leading-6 text-destructive shadow-[0_0_0_1px_rgba(220,38,38,0.18)]">
+                Encrypted snippets were detected. Resetting settings can make them unavailable because the original password verifier and derivation salt are stored in this file.
+              </p>
+            )}
+
+            {confirmation === "settings" ? (
+              <div className="mt-4 rounded-lg bg-destructive/8 p-3 shadow-[0_0_0_1px_rgba(220,38,38,0.18)]">
+                <p className="text-pretty text-sm font-medium">
+                  Reset settings to defaults and preserve the original file in quarantine?
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    className={actionClassName}
+                    disabled={isBusy}
+                    onClick={() => setConfirmation(null)}
+                    variant="outline"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    className={actionClassName}
+                    disabled={isBusy}
+                    onClick={resetSettings}
+                    variant="destructive"
+                  >
+                    {busyAction === "reset-settings" && (
+                      <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+                    )}
+                    Quarantine and reset settings
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                className={`mt-3 ${actionClassName}`}
+                disabled={isBusy}
+                onClick={() => setConfirmation("settings")}
+                variant="outline"
+              >
+                <RotateCcw aria-hidden="true" />
+                Reset settings
+              </Button>
+            )}
+          </section>
+        )}
+
+        <div aria-live="polite" className="mt-5 min-h-5 text-sm">
+          {error && <p className="text-pretty text-destructive">{error}</p>}
+          {!error && notice && <p className="text-pretty text-muted-foreground">{notice}</p>}
+        </div>
+
+        <footer className="mt-3 flex flex-wrap gap-2 border-t border-border/60 pt-4">
+          <Button
+            className={actionClassName}
+            disabled={isBusy}
+            onClick={retry}
+            variant="secondary"
+          >
+            {busyAction === "retry" ? (
+              <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+            ) : (
+              <RefreshCw aria-hidden="true" />
+            )}
+            Retry
+          </Button>
+          <Button
+            className={actionClassName}
+            disabled={isBusy}
+            onClick={openDirectory}
+            variant="ghost"
+          >
+            <FolderOpen aria-hidden="true" />
+            Open data folder
+          </Button>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/components/StorageRecovery.tsx
+++ b/src/components/StorageRecovery.tsx
@@ -20,7 +20,7 @@ interface StorageRecoveryProps {
   onRetry: () => Promise<void>;
 }
 
-type RecoveryAction = "restore" | "reset-data" | "reset-settings" | "discard-vault" | "retry" | "open";
+type RecoveryAction = "restore" | "recover-vault" | "reset-data" | "reset-settings" | "discard-vault" | "retry" | "open";
 type Confirmation = "data" | "settings" | "vault" | null;
 
 const actionClassName =
@@ -96,6 +96,9 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
   const [notice, setNotice] = useState<string | null>(null);
 
   const isBusy = busyAction !== null;
+  const proposedDataBackup = status.dataIssue && status.settingsIssue && status.hasEncryptedSecrets
+    ? status.newestVaultBackup
+    : status.newestValidBackup;
 
   const runAction = async (
     action: RecoveryAction,
@@ -114,12 +117,35 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
   };
 
   const restoreBackup = () => {
-    const backup = status.newestValidBackup;
+    const backup = proposedDataBackup;
     if (!backup) return;
 
     void runAction("restore", async () => {
       await api.restoreBackup(backup.filename);
       setNotice("The newest valid backup was restored.");
+      await onRetry();
+    });
+  };
+
+  const restoreVaultBackup = () => {
+    const backup = status.newestVaultBackup;
+    if (!backup) return;
+
+    void runAction("restore", async () => {
+      await api.restoreBackup(backup.filename);
+      setNotice("The newest backup with vault metadata was restored.");
+      await onRetry();
+    });
+  };
+
+  const recoverVaultMetadata = () => {
+    void runAction("recover-vault", async () => {
+      const recoveryCopy = await api.recoverVaultMetadata();
+      setNotice(
+        recoveryCopy
+          ? `Vault settings were restored. The previous settings were preserved as ${recoveryCopy}.`
+          : "Vault settings were restored from the recovery metadata in sklad.json.",
+      );
       await onRetry();
     });
   };
@@ -198,20 +224,20 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
         {status.dataIssue?.kind === "invalid_format" && (
           <section className="mt-5 rounded-xl bg-primary/6 p-4 shadow-[0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07)]">
             <h2 className="text-sm font-semibold">Snippet recovery</h2>
-            {status.newestValidBackup ? (
+            {proposedDataBackup ? (
               <>
                 <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
                   The newest valid backup was created on{" "}
                   <time
                     className="font-medium text-foreground"
-                    dateTime={backupDateTime(status.newestValidBackup.timestamp)}
+                    dateTime={backupDateTime(proposedDataBackup.timestamp)}
                   >
-                    {formatBackupTimestamp(status.newestValidBackup.timestamp)}
+                    {formatBackupTimestamp(proposedDataBackup.timestamp)}
                   </time>
                   .
                 </p>
                 <p className="mt-1 break-all font-mono text-xs leading-5 text-muted-foreground">
-                  {status.newestValidBackup.filename}
+                  {proposedDataBackup.filename}
                 </p>
               </>
             ) : (
@@ -249,7 +275,7 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
               </div>
             ) : (
               <div className="mt-4 flex flex-wrap gap-2">
-                {status.newestValidBackup && (
+                {proposedDataBackup && (
                   <Button
                     className={actionClassName}
                     disabled={isBusy}
@@ -329,18 +355,60 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
           (status.settingsIssue.kind === "vault_metadata" ||
             status.settingsIssue.kind === "invalid_format") && (
             <section className="mt-5 rounded-xl bg-destructive/6 p-4 shadow-[0_0_0_1px_rgba(220,38,38,0.16)]">
-              <h2 className="text-balance text-sm font-semibold">Unavailable vault recovery</h2>
+              <h2 className="text-balance text-sm font-semibold">
+                {status.vaultMetadataRecoverable || status.newestVaultBackup
+                  ? "Vault metadata recovery"
+                  : "Unavailable vault recovery"}
+              </h2>
               {status.dataIssue ? (
                 <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
-                  Recover the snippet file first. Sklad must be able to read it before it can preserve public snippets and remove encrypted ones safely.
+                  Recover the snippet file first. When the proposed backup contains vault metadata, Sklad restores the encrypted data and its required settings together.
                 </p>
               ) : (
                 <>
-                  <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
-                    The original vault cannot be unlocked safely from the available metadata. You can keep inspecting the files manually, or reset the vault and retain only readable public snippets.
-                  </p>
+                  {status.vaultMetadataRecoverable ? (
+                    <>
+                      <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+                        Sklad found a recovery copy of the vault metadata inside the snippet file. Restore it to settings, then unlock the vault with the existing master password.
+                      </p>
+                      <Button
+                        className={`mt-3 ${actionClassName}`}
+                        disabled={isBusy}
+                        onClick={recoverVaultMetadata}
+                      >
+                        {busyAction === "recover-vault" ? (
+                          <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+                        ) : (
+                          <ArchiveRestore aria-hidden="true" />
+                        )}
+                        Restore vault metadata
+                      </Button>
+                    </>
+                  ) : status.newestVaultBackup ? (
+                    <>
+                      <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+                        The active snippet file has no recoverable vault metadata, but a self-contained encrypted backup is available. Restoring it also restores the metadata required by the existing master password.
+                      </p>
+                      <Button
+                        className={`mt-3 ${actionClassName}`}
+                        disabled={isBusy}
+                        onClick={restoreVaultBackup}
+                      >
+                        {busyAction === "restore" ? (
+                          <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+                        ) : (
+                          <ArchiveRestore aria-hidden="true" />
+                        )}
+                        Restore encrypted backup
+                      </Button>
+                    </>
+                  ) : (
+                    <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+                      The original vault cannot be unlocked safely from the available metadata. You can keep inspecting the files manually, or reset the vault and retain only readable public snippets.
+                    </p>
+                  )}
                   <p className="mt-3 rounded-lg bg-background/65 px-3 py-2 text-pretty text-sm leading-6 text-muted-foreground shadow-[inset_0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]">
-                    Before changing active data, Sklad preserves existing data and settings as recovery copies. Existing backups are left untouched.
+                    If you reset instead, Sklad preserves existing data and settings as recovery copies, then removes encrypted snippets from the active library. Existing backups are left untouched.
                   </p>
 
                   {confirmation === "vault" ? (

--- a/src/components/StorageRecovery.tsx
+++ b/src/components/StorageRecovery.tsx
@@ -24,7 +24,22 @@ type RecoveryAction = "restore" | "reset-data" | "reset-settings" | "discard-vau
 type Confirmation = "data" | "settings" | "vault" | null;
 
 const actionClassName =
-  "min-h-10 active:scale-[0.96] transition-[color,background-color,border-color,box-shadow,transform]";
+  "min-h-10 max-w-full active:scale-[0.96] transition-[color,background-color,border-color,box-shadow,transform] max-sm:h-auto max-sm:min-h-11 max-sm:whitespace-normal";
+
+function formatBackupTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "Unknown date";
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function backupDateTime(timestamp: number): string | undefined {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
 
 function readableError(error: unknown): string {
   if (typeof error === "string") return error;
@@ -48,7 +63,7 @@ function IssueCard({ issue }: { issue: StorageIssue }) {
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <h2 className="font-mono text-sm font-semibold">{issue.fileName}</h2>
+            <h2 className="break-words font-mono text-sm font-semibold">{issue.fileName}</h2>
             <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
               {isVaultMetadata
                 ? "Vault metadata"
@@ -64,7 +79,7 @@ function IssueCard({ issue }: { issue: StorageIssue }) {
               ? "The JSON or its expected structure is invalid. Sklad will not load or overwrite this file until you choose a recovery action."
               : "Sklad cannot safely read this file. Check its permissions or disk availability, then retry."}
           </p>
-          <code className="mt-3 block overflow-x-auto rounded-lg bg-background/75 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground shadow-[inset_0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]">
+          <code className="mt-3 block min-w-0 whitespace-pre-wrap break-words rounded-lg bg-background/75 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground shadow-[inset_0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]">
             {issue.reason}
           </code>
         </div>
@@ -156,8 +171,8 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
   };
 
   return (
-    <main className="flex min-h-screen w-screen items-center justify-center overflow-auto bg-industrial p-6 text-foreground">
-      <div className="w-full max-w-2xl rounded-2xl bg-card p-6 shadow-xl ring-1 ring-black/5 dark:ring-white/10">
+    <main className="flex min-h-screen w-full min-w-0 items-center justify-center overflow-x-hidden overflow-y-auto bg-industrial p-4 text-foreground sm:p-6">
+      <div className="min-w-0 w-full max-w-2xl rounded-2xl bg-card p-5 shadow-xl ring-1 ring-black/5 sm:p-6 dark:ring-white/10">
         <header className="flex items-start gap-4">
           <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-primary/12 text-primary shadow-[0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.08)]">
             <ShieldAlert aria-hidden="true" className="size-6" />
@@ -186,21 +201,18 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
             {status.newestValidBackup ? (
               <>
                 <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
-                  A valid backup is available: <span className="font-mono text-foreground">{status.newestValidBackup.filename}</span>.
+                  The newest valid backup was created on{" "}
+                  <time
+                    className="font-medium text-foreground"
+                    dateTime={backupDateTime(status.newestValidBackup.timestamp)}
+                  >
+                    {formatBackupTimestamp(status.newestValidBackup.timestamp)}
+                  </time>
+                  .
                 </p>
-                <Button
-                  className={`mt-3 ${actionClassName}`}
-                  disabled={isBusy}
-                  onClick={restoreBackup}
-                  size="lg"
-                >
-                  {busyAction === "restore" ? (
-                    <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
-                  ) : (
-                    <ArchiveRestore aria-hidden="true" />
-                  )}
-                  Restore newest valid backup
-                </Button>
+                <p className="mt-1 break-all font-mono text-xs leading-5 text-muted-foreground">
+                  {status.newestValidBackup.filename}
+                </p>
               </>
             ) : (
               <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
@@ -236,15 +248,31 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
                 </div>
               </div>
             ) : (
-              <Button
-                className={`mt-3 ${actionClassName}`}
-                disabled={isBusy}
-                onClick={() => setConfirmation("data")}
-                variant="outline"
-              >
-                <RotateCcw aria-hidden="true" />
-                Create fresh library
-              </Button>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {status.newestValidBackup && (
+                  <Button
+                    className={actionClassName}
+                    disabled={isBusy}
+                    onClick={restoreBackup}
+                  >
+                    {busyAction === "restore" ? (
+                      <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+                    ) : (
+                      <ArchiveRestore aria-hidden="true" />
+                    )}
+                    Restore newest valid backup
+                  </Button>
+                )}
+                <Button
+                  className={actionClassName}
+                  disabled={isBusy}
+                  onClick={() => setConfirmation("data")}
+                  variant="outline"
+                >
+                  <RotateCcw aria-hidden="true" />
+                  Create fresh library
+                </Button>
+              </div>
             )}
           </section>
         )}

--- a/src/components/StorageRecovery.tsx
+++ b/src/components/StorageRecovery.tsx
@@ -3,22 +3,25 @@ import {
   ArchiveRestore,
   FileWarning,
   FolderOpen,
+  KeyRound,
   LoaderCircle,
   RefreshCw,
   RotateCcw,
   ShieldAlert,
+  Trash2,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { StorageIssue, StorageStatus } from "@/types";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 interface StorageRecoveryProps {
   status: StorageStatus;
   onRetry: () => Promise<void>;
 }
 
-type RecoveryAction = "restore" | "reset-data" | "reset-settings" | "retry" | "open";
-type Confirmation = "data" | "settings" | null;
+type RecoveryAction = "restore" | "reset-data" | "reset-settings" | "discard-vault" | "retry" | "open";
+type Confirmation = "data" | "settings" | "vault" | null;
 
 const actionClassName =
   "min-h-10 active:scale-[0.96] transition-[color,background-color,border-color,box-shadow,transform]";
@@ -31,22 +34,33 @@ function readableError(error: unknown): string {
 
 function IssueCard({ issue }: { issue: StorageIssue }) {
   const isInvalid = issue.kind === "invalid_format";
+  const isVaultMetadata = issue.kind === "vault_metadata";
 
   return (
     <section className="rounded-xl bg-muted/45 p-4 shadow-[0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.08)]">
       <div className="flex items-start gap-3">
         <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
-          <FileWarning aria-hidden="true" className="size-5" />
+          {isVaultMetadata ? (
+            <KeyRound aria-hidden="true" className="size-5" />
+          ) : (
+            <FileWarning aria-hidden="true" className="size-5" />
+          )}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <h2 className="font-mono text-sm font-semibold">{issue.fileName}</h2>
             <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
-              {isInvalid ? "Invalid format" : "Unreadable"}
+              {isVaultMetadata
+                ? "Vault metadata"
+                : isInvalid
+                  ? "Invalid format"
+                  : "Unreadable"}
             </span>
           </div>
           <p className="mt-2 text-pretty text-sm leading-6 text-muted-foreground">
-            {isInvalid
+            {isVaultMetadata
+              ? "Sklad cannot safely unlock the encrypted snippets with the available settings. Normal access remains blocked and no files are changed automatically."
+              : isInvalid
               ? "The JSON or its expected structure is invalid. Sklad will not load or overwrite this file until you choose a recovery action."
               : "Sklad cannot safely read this file. Check its permissions or disk availability, then retry."}
           </p>
@@ -62,6 +76,7 @@ function IssueCard({ issue }: { issue: StorageIssue }) {
 export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
   const [busyAction, setBusyAction] = useState<RecoveryAction | null>(null);
   const [confirmation, setConfirmation] = useState<Confirmation>(null);
+  const [vaultConfirmation, setVaultConfirmation] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -110,6 +125,26 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
       setNotice(`The original settings were preserved as ${quarantine}.`);
       await onRetry();
     });
+  };
+
+  const discardVaultData = () => {
+    void runAction("discard-vault", async () => {
+      const result = await api.discardUnrecoverableVaultData();
+      setConfirmation(null);
+      setVaultConfirmation("");
+      const source = result.restoredFromBackup
+        ? ` Public snippets were recovered from ${result.restoredFromBackup}.`
+        : "";
+      setNotice(
+        `${result.removedSecretCount} unavailable encrypted ${result.removedSecretCount === 1 ? "snippet was" : "snippets were"} removed.${source}`,
+      );
+      await onRetry();
+    });
+  };
+
+  const cancelConfirmation = () => {
+    setConfirmation(null);
+    setVaultConfirmation("");
   };
 
   const retry = () => {
@@ -182,7 +217,7 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
                   <Button
                     className={actionClassName}
                     disabled={isBusy}
-                    onClick={() => setConfirmation(null)}
+                    onClick={cancelConfirmation}
                     variant="outline"
                   >
                     Cancel
@@ -214,18 +249,12 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
           </section>
         )}
 
-        {status.settingsIssue?.kind === "invalid_format" && (
+        {status.settingsIssue?.kind === "invalid_format" && !status.hasEncryptedSecrets && (
           <section className="mt-5 rounded-xl bg-muted/35 p-4 shadow-[0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07)]">
             <h2 className="text-sm font-semibold">Settings recovery</h2>
             <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
               Sklad does not currently back up settings. Resetting restores defaults only after preserving the damaged file.
             </p>
-            {status.hasEncryptedSecrets && (
-              <p className="mt-3 text-pretty rounded-lg bg-destructive/8 px-3 py-2 text-sm leading-6 text-destructive shadow-[0_0_0_1px_rgba(220,38,38,0.18)]">
-                Encrypted snippets were detected. Resetting settings can make them unavailable because the original password verifier and derivation salt are stored in this file.
-              </p>
-            )}
-
             {confirmation === "settings" ? (
               <div className="mt-4 rounded-lg bg-destructive/8 p-3 shadow-[0_0_0_1px_rgba(220,38,38,0.18)]">
                 <p className="text-pretty text-sm font-medium">
@@ -235,7 +264,7 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
                   <Button
                     className={actionClassName}
                     disabled={isBusy}
-                    onClick={() => setConfirmation(null)}
+                    onClick={cancelConfirmation}
                     variant="outline"
                   >
                     Cancel
@@ -266,6 +295,82 @@ export function StorageRecovery({ status, onRetry }: StorageRecoveryProps) {
             )}
           </section>
         )}
+
+        {status.hasEncryptedSecrets &&
+          status.settingsIssue &&
+          (status.settingsIssue.kind === "vault_metadata" ||
+            status.settingsIssue.kind === "invalid_format") && (
+            <section className="mt-5 rounded-xl bg-destructive/6 p-4 shadow-[0_0_0_1px_rgba(220,38,38,0.16)]">
+              <h2 className="text-balance text-sm font-semibold">Unavailable vault recovery</h2>
+              {status.dataIssue ? (
+                <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+                  Recover the snippet file first. Sklad must be able to read it before it can preserve public snippets and remove encrypted ones safely.
+                </p>
+              ) : (
+                <>
+                  <p className="mt-1 text-pretty text-sm leading-6 text-muted-foreground">
+                    The original vault cannot be unlocked safely from the available metadata. You can keep inspecting the files manually, or reset the vault and retain only readable public snippets.
+                  </p>
+                  <p className="mt-3 rounded-lg bg-background/65 px-3 py-2 text-pretty text-sm leading-6 text-muted-foreground shadow-[inset_0_0_0_1px_rgba(0,0,0,0.05)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]">
+                    Before changing active data, Sklad preserves existing data and settings as recovery copies. Existing backups are left untouched.
+                  </p>
+
+                  {confirmation === "vault" ? (
+                    <div className="mt-4 rounded-lg bg-destructive/8 p-3 shadow-[0_0_0_1px_rgba(220,38,38,0.22)]">
+                      <p className="text-pretty text-sm font-medium">
+                        This permanently removes encrypted snippets from the active library and resets vault settings.
+                      </p>
+                      <label className="mt-3 block text-xs font-medium text-muted-foreground" htmlFor="vault-recovery-confirmation">
+                        Type <span className="font-mono text-foreground">DELETE</span> to confirm
+                      </label>
+                      <Input
+                        autoComplete="off"
+                        className="mt-2 min-h-10 font-mono"
+                        disabled={isBusy}
+                        id="vault-recovery-confirmation"
+                        onChange={(event) => setVaultConfirmation(event.target.value)}
+                        spellCheck={false}
+                        value={vaultConfirmation}
+                      />
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        <Button
+                          className={actionClassName}
+                          disabled={isBusy}
+                          onClick={cancelConfirmation}
+                          variant="outline"
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          className={actionClassName}
+                          disabled={isBusy || vaultConfirmation !== "DELETE"}
+                          onClick={discardVaultData}
+                          variant="destructive"
+                        >
+                          {busyAction === "discard-vault" ? (
+                            <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" />
+                          ) : (
+                            <Trash2 aria-hidden="true" />
+                          )}
+                          Remove encrypted snippets
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <Button
+                      className={`mt-3 ${actionClassName}`}
+                      disabled={isBusy}
+                      onClick={() => setConfirmation("vault")}
+                      variant="outline"
+                    >
+                      <Trash2 aria-hidden="true" />
+                      Reset unavailable vault
+                    </Button>
+                  )}
+                </>
+              )}
+            </section>
+          )}
 
         <div aria-live="polite" className="mt-5 min-h-5 text-sm">
           {error && <p className="text-pretty text-destructive">{error}</p>}

--- a/src/components/VaultLock.tsx
+++ b/src/components/VaultLock.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { api } from "../lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,6 +22,23 @@ export function VaultLock({ onUnlock, onReset, onCancel, isInit = false, mode = 
     const [showOptions, setShowOptions] = useState(false);
     const [confirmReset, setConfirmReset] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
+    const [appVersion, setAppVersion] = useState<string | null>(null);
+
+    useEffect(() => {
+        let isActive = true;
+        void import("@tauri-apps/api/app")
+            .then(({ getVersion }) => getVersion())
+            .then((version) => {
+                if (isActive) setAppVersion(version);
+            })
+            .catch(() => {
+                if (isActive) setAppVersion(null);
+            });
+
+        return () => {
+            isActive = false;
+        };
+    }, []);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -218,9 +235,11 @@ export function VaultLock({ onUnlock, onReset, onCancel, isInit = false, mode = 
             </Card>
 
             {/* Version indicator */}
-            <div className="absolute bottom-4 text-xs text-muted-foreground/40 font-mono">
-                SKLAD v0.2.1
-            </div>
+            {appVersion && (
+                <div className="absolute bottom-4 font-mono text-xs text-muted-foreground/40">
+                    SKLAD v{appVersion}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { Node, AppSettings, BackupInfo } from "../types";
+import { Node, AppSettings, BackupInfo, StorageStatus } from "../types";
 
 export const api = {
     getData: (): Promise<Node[]> => invoke("get_data"),
@@ -33,5 +33,12 @@ export const api = {
     getBackups: (): Promise<BackupInfo[]> => invoke("get_backups"),
 
     restoreBackup: (filename: string): Promise<void> => invoke("restore_backup", { filename }),
-};
 
+    getStorageStatus: (): Promise<StorageStatus> => invoke("get_storage_status"),
+
+    resetCorruptData: (): Promise<string> => invoke("reset_corrupt_data"),
+
+    resetCorruptSettings: (): Promise<string> => invoke("reset_corrupt_settings"),
+
+    openDataDirectory: (): Promise<void> => invoke("open_data_directory"),
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { Node, AppSettings, BackupInfo, StorageStatus } from "../types";
+import { Node, AppSettings, BackupInfo, StorageStatus, VaultRecoveryResult } from "../types";
 
 export const api = {
     getData: (): Promise<Node[]> => invoke("get_data"),
@@ -39,6 +39,9 @@ export const api = {
     resetCorruptData: (): Promise<string> => invoke("reset_corrupt_data"),
 
     resetCorruptSettings: (): Promise<string> => invoke("reset_corrupt_settings"),
+
+    discardUnrecoverableVaultData: (): Promise<VaultRecoveryResult> =>
+        invoke("discard_unrecoverable_vault_data"),
 
     openDataDirectory: (): Promise<void> => invoke("open_data_directory"),
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -40,6 +40,8 @@ export const api = {
 
     resetCorruptSettings: (): Promise<string> => invoke("reset_corrupt_settings"),
 
+    recoverVaultMetadata: (): Promise<string | null> => invoke("recover_vault_metadata"),
+
     discardUnrecoverableVaultData: (): Promise<VaultRecoveryResult> =>
         invoke("discard_unrecoverable_vault_data"),
 

--- a/src/lib/storageRecovery.ts
+++ b/src/lib/storageRecovery.ts
@@ -1,0 +1,15 @@
+import { getCurrentWebviewWindow, WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { api } from "@/lib/api";
+
+export async function routeToStorageRecovery(): Promise<boolean> {
+  const status = await api.getStorageStatus();
+  if (!status.dataIssue && !status.settingsIssue) return false;
+
+  const mainWindow = await WebviewWindow.getByLabel("main");
+  if (mainWindow) {
+    await mainWindow.show();
+    await mainWindow.setFocus();
+  }
+  await getCurrentWebviewWindow().hide();
+  return true;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,6 @@ export interface AppSettings {
     theme: 'dark' | 'light' | 'system';
     security: {
         lockTimeout: number;
-        clearClipboard: boolean;
         masterPasswordEnabled: boolean;
     };
     loggingEnabled: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,23 @@ export interface BackupInfo {
     size: number;
 }
 
+export type StorageFile = 'data' | 'settings';
+export type StorageIssueKind = 'invalid_format' | 'unreadable';
+
+export interface StorageIssue {
+    file: StorageFile;
+    kind: StorageIssueKind;
+    fileName: string;
+    reason: string;
+}
+
+export interface StorageStatus {
+    dataIssue: StorageIssue | null;
+    settingsIssue: StorageIssue | null;
+    newestValidBackup: BackupInfo | null;
+    hasEncryptedSecrets: boolean;
+}
+
 export interface Node {
     id: string;             // UUID v4
     type: NodeType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface BackupInfo {
 }
 
 export type StorageFile = 'data' | 'settings';
-export type StorageIssueKind = 'invalid_format' | 'unreadable';
+export type StorageIssueKind = 'invalid_format' | 'unreadable' | 'vault_metadata';
 
 export interface StorageIssue {
     file: StorageFile;
@@ -21,6 +21,13 @@ export interface StorageStatus {
     settingsIssue: StorageIssue | null;
     newestValidBackup: BackupInfo | null;
     hasEncryptedSecrets: boolean;
+}
+
+export interface VaultRecoveryResult {
+    removedSecretCount: number;
+    dataRecoveryCopy: string | null;
+    settingsRecoveryCopy: string | null;
+    restoredFromBackup: string | null;
 }
 
 export interface Node {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface BackupInfo {
     filename: string;
     timestamp: number;
     size: number;
+    hasVaultMetadata: boolean;
 }
 
 export type StorageFile = 'data' | 'settings';
@@ -20,7 +21,9 @@ export interface StorageStatus {
     dataIssue: StorageIssue | null;
     settingsIssue: StorageIssue | null;
     newestValidBackup: BackupInfo | null;
+    newestVaultBackup: BackupInfo | null;
     hasEncryptedSecrets: boolean;
+    vaultMetadataRecoverable: boolean;
 }
 
 export interface VaultRecoveryResult {


### PR DESCRIPTION
## Summary

Prepare Sklad 0.2.3 with explicit storage recovery. Damaged storage or unavailable vault settings now lead to recovery instead of silently presenting an empty library. Encrypted libraries and backups carry versioned vault metadata for recovery with the existing master password.

- Preserve source files before recovery, validate restores, and retain atomic writes.
- Add storage compatibility/recovery and vault cryptography tests, pull-request CI, and a clean Clippy baseline.
- Update release action pins, package metadata, and application versions to 0.2.3.
- Improve recovery UI, remove duplicate search icons, show the actual app version, and polish landing-page icons and spacing.
- Remove the dormant clipboard setting while retaining older-file compatibility.

## Upgrade and rollback

The application identifier remains `sklad`, and the data directory stays unchanged. Version 0.2.3 reads 0.2.2 files. Before upgrading, fully quit Sklad through the tray and separately copy both `sklad.json` and `settings.json` as a matching snapshot.

Before migrating a healthy legacy encrypted library, Sklad preserves its exact bytes beside the original as `sklad.pre_metadata_migration_<unix_ms>.json`. This copies the library only, not settings. Libraries without encrypted snippets retain the array format.

Version 0.2.2 cannot read the new encrypted format and may show an empty library; saving could overwrite it. To downgrade, fully quit Sklad, separately preserve the current data folder, install 0.2.2 without launching it, and restore both files from the matching pre-upgrade snapshot before starting. Later changes will not appear in that snapshot. The automatic migration copy can substitute for the old data file only with corresponding original vault settings. New encrypted backups are also incompatible with 0.2.2. Include this guidance in the public release notes.

## Validation

- Windows Rust tests rerun on 2026-09-10: 33 passed; `git diff --check` passed.
- Maintainer reports the main Windows flows work in manual testing.
- Previous candidate validation passed frontend build, Rust formatting and Clippy; Linux DEB/RPM/AppImage builds and narrow/wide landing-page checks were also completed.
- PR CI should rerun frontend build, Rust formatting, tests, and Clippy.

## Before publication

Verify all platform artifacts and test the final Windows installer, including upgrading existing 0.2.2 data. Exact installed-upgrade/rollback coverage and macOS behavior are not yet confirmed. Merge and tag after review; the tag-triggered workflow creates a draft release for artifact verification.
